### PR TITLE
Waitingでどのデッキを選ぶ

### DIFF
--- a/frontend/src/app/room/[roomId]/[status]/_components/DeckSelector.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/DeckSelector.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { mockApi } from '@/lib/mockApi';
+import type { MockUser, MockRoom, MockRoomPlayer, MockDeck } from '@/lib/types';
+
+interface DeckSelectorProps {
+    room: MockRoom;
+    currentUser: MockUser;
+    currentPlayer: MockRoomPlayer;
+    onDeckSelected: () => void;
+}
+
+export function DeckSelector({ room, currentUser, currentPlayer, onDeckSelected }: DeckSelectorProps) {
+    const [decks, setDecks] = useState<MockDeck[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [isSelecting, setIsSelecting] = useState(false);
+    const [selectedDeckId, setSelectedDeckId] = useState<string>(currentPlayer.selectedDeckId || '');
+
+    // デッキ一覧を取得
+    useEffect(() => {
+        const loadDecks = async () => {
+            try {
+                setIsLoading(true);
+                setError(null);
+                const userDecks = await mockApi.getDecks({ currentUser });
+                setDecks(userDecks);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : 'デッキの取得に失敗しました');
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        loadDecks();
+    }, [currentUser]);
+
+    const handleSelectDeck = async (deckId: string) => {
+        setIsSelecting(true);
+        try {
+            await mockApi.selectDeck({
+                roomId: room.id,
+                currentUser,
+                deckId
+            });
+            setSelectedDeckId(deckId);
+            onDeckSelected();
+        } catch (error) {
+            alert(error instanceof Error ? error.message : 'デッキ選択に失敗しました');
+        } finally {
+            setIsSelecting(false);
+        }
+    };
+
+    if (isLoading) {
+        return <div>デッキを読み込み中...</div>;
+    }
+
+    if (error) {
+        return <div style={{ color: 'red' }}>デッキの取得に失敗しました: {error}</div>;
+    }
+
+    if (!decks || decks.length === 0) {
+        return (
+            <div >
+                <h3>デッキ選択</h3>
+                <p>デッキがありません。先にデッキを作成してください。</p>
+            </div>
+        );
+    }
+
+    const selectedDeck = decks.find(deck => deck.id === selectedDeckId);
+
+    return (
+        <div >
+            <h3>デッキ選択</h3>
+            {selectedDeck && (
+                <div >
+                    <strong>選択中: {selectedDeck.name}</strong>
+                </div>
+            )}
+
+            <div>
+                {decks.map((deck: MockDeck) => (
+                    <div key={deck.id} >
+                        <div >
+                            <div>
+                                <strong>{deck.name}</strong>
+                            </div>
+                            <button
+                                onClick={() => handleSelectDeck(deck.id)}
+                                disabled={isSelecting || deck.id === selectedDeckId}>
+                                {deck.id === selectedDeckId ? '選択中' : '選択'}
+                            </button>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import { useAtom } from 'jotai';
 import { currentUserAtom } from '@/lib/atoms';
 import { useState } from 'react';
+import { DeckSelector } from './DeckSelector';
 
 interface RoomDisplayProps {
     room: MockRoom;
@@ -18,6 +19,11 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
     const router = useRouter();
     const [currentUser] = useAtom(currentUserAtom);
     const [isStartingGame, setIsStartingGame] = useState(false);
+    const [, forceUpdate] = useState({});
+
+    const refreshData = () => {
+        forceUpdate({});
+    };
 
     const handleBackHome = () => {
         router.push('/home');
@@ -97,6 +103,15 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
                                 <div>
                                     <span>HP: {player.hp}/{GAME_CONSTANTS.MAX_HP}</span>
                                     <p>PP: {player.pp}/{calculatePPMax(player.turn)}</p>
+                                    {room.status === 'waiting' && (
+                                        <p>
+                                            デッキ: {player.selectedDeckId ? (
+                                                <span style={{ color: 'green' }}>選択済み</span>
+                                            ) : (
+                                                <span style={{ color: 'orange' }}>未選択</span>
+                                            )}
+                                        </p>
+                                    )}
                                 </div>
                             </div>
                         </div>
@@ -123,6 +138,23 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
                             {roomPlayers.length < 2 && (
                                 <p>もう1人のプレイヤーを待っています...</p>
                             )}
+
+                            {/* 現在のユーザーのデッキ選択 */}
+                            {(() => {
+                                const currentPlayer = roomPlayers.find(p => p.userId === currentUser.id);
+                                if (currentPlayer) {
+                                    return (
+                                        <DeckSelector
+                                            room={room}
+                                            currentUser={currentUser}
+                                            currentPlayer={currentPlayer}
+                                            onDeckSelected={refreshData}
+                                        />
+                                    );
+                                }
+                                return null;
+                            })()}
+
                             {roomPlayers.length === 2 && room.ownerId === currentUser.id && (
                                 <div>
                                     <p>プレイヤーが揃いました！</p>

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -1,6 +1,6 @@
 import { getUserById, getActivePlayer, calculatePPMax } from '@/lib/gameLogic';
 import { GAME_CONSTANTS } from '@/lib/constants';
-import { mockUsers, getPlayersByRoomId } from '@/lib/mockData';
+import { mockUsers, getPlayersByRoomId, getDeckById } from '@/lib/mockData';
 import { mockApi } from '@/lib/mockApi';
 import type { MockRoom, MockRoomPlayer } from '@/lib/types';
 import { useRouter } from 'next/navigation';
@@ -83,6 +83,9 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
                     const isActivePlayer = activePlayer?.userId === player.userId;
                     const playerPosition = index === 0 ? '先攻' : '後攻';
 
+                    // デッキ情報を取得
+                    const selectedDeck = player.selectedDeckId ? getDeckById(player.selectedDeckId) : null;
+
                     return (
                         <div key={player.id}>
                             <div>
@@ -103,12 +106,25 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
                                 <div>
                                     <span>HP: {player.hp}/{GAME_CONSTANTS.MAX_HP}</span>
                                     <p>PP: {player.pp}/{calculatePPMax(player.turn)}</p>
+
+                                    {/* デッキ情報表示 */}
                                     {room.status === 'waiting' && (
                                         <p>
                                             デッキ: {player.selectedDeckId ? (
                                                 <span style={{ color: 'green' }}>選択済み</span>
                                             ) : (
                                                 <span style={{ color: 'orange' }}>未選択</span>
+                                            )}
+                                        </p>
+                                    )}
+
+                                    {room.status === 'playing' && (
+                                        <p >
+                                            [DEBUG] デッキ: {selectedDeck ? selectedDeck.name : '未選択'}
+                                            {player.selectedDeckId && (
+                                                <span style={{ marginLeft: '5px' }}>
+                                                    (ID: {player.selectedDeckId})
+                                                </span>
                                             )}
                                         </p>
                                     )}
@@ -203,6 +219,30 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
                                 </div>
                             )}
                         </div>
+                    </div>
+                )}
+
+                {room.status === 'playing' && (
+                    <div>
+                        <h4 >
+                            [DEBUG] デッキ選択状況
+                        </h4>
+                        {roomPlayers.map((player, index) => {
+                            const user = getUserById(player.userId, mockUsers);
+                            const selectedDeck = player.selectedDeckId ? getDeckById(player.selectedDeckId) : null;
+                            return (
+                                <div key={player.id} >
+                                    <strong>{user?.name}</strong>: {' '}
+                                    {selectedDeck ? (
+                                        <span style={{ color: '#28a745' }}>
+                                            {selectedDeck.name} (ID: {player.selectedDeckId})
+                                        </span>
+                                    ) : (
+                                        <span style={{ color: '#dc3545' }}>デッキ未選択</span>
+                                    )}
+                                </div>
+                            );
+                        })}
                     </div>
                 )}
 

--- a/frontend/src/app/room/[roomId]/[status]/_components/index.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_components/index.ts
@@ -1,2 +1,3 @@
 export { RoomDisplay } from './RoomDisplay';
 export { GameControls } from './GameControls';
+export { DeckSelector } from './DeckSelector';

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useRoomData.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useRoomData.ts
@@ -18,9 +18,9 @@ export function useRoomData() {
     const [, setError] = useAtom(errorAtom);
 
     useEffect(() => {
-        if (room && room.status !== status) {
+        if (room && status && room.status !== status) {
             const newUrl = `/room/${encodeURIComponent(roomId)}/${room.status}`;
-            router.replace(newUrl);
+            router.push(newUrl);
         }
     }, [room, status, roomId, router]);
 

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -1,5 +1,5 @@
 import { GAME_CONSTANTS } from './constants';
-import type { MockUser, MockRoom, MockRoomPlayer } from './types';
+import type { MockUser, MockRoom, MockRoomPlayer, MockDeck } from './types';
 
 // ユーザー
 export const mockUsers: MockUser[] = [
@@ -32,6 +32,7 @@ export let mockRoomPlayers: MockRoomPlayer[] = [
         pp: 1,
         turn: 1,
         turnStatus: 'active',
+        selectedDeckId: 'deck3'
     },
     {
         id: 'player2',
@@ -41,6 +42,7 @@ export let mockRoomPlayers: MockRoomPlayer[] = [
         pp: 1,
         turn: 1,
         turnStatus: 'active',
+        selectedDeckId: 'undefined',
     },
     {
         id: 'player3',
@@ -50,6 +52,36 @@ export let mockRoomPlayers: MockRoomPlayer[] = [
         pp: 0,
         turn: 1,
         turnStatus: 'ended',
+        selectedDeckId: 'deck1',
+    },
+];
+
+// デッキ
+export let mockDecks: MockDeck[] = [
+    {
+        id: 'deck1',
+        name: '攻撃型デッキ',
+        userId: 'user1',
+    },
+    {
+        id: 'deck2',
+        name: '防御型デッキ',
+        userId: 'user1',
+    },
+    {
+        id: 'deck3',
+        name: 'バランス型デッキ',
+        userId: 'user2',
+    },
+    {
+        id: 'deck4',
+        name: '実験デッキ',
+        userId: 'user2',
+    },
+    {
+        id: 'deck5',
+        name: 'コントロールデッキ',
+        userId: 'user3',
     },
 ];
 
@@ -71,4 +103,14 @@ export const getPlayersByRoomId = (roomId: string): MockRoomPlayer[] => {
 // 特定のプレイヤーを取得する関数
 export const getPlayerByUserIdAndRoomId = (userId: string, roomId: string): MockRoomPlayer | undefined => {
     return mockRoomPlayers.find(p => p.userId === userId && p.roomId === roomId);
+};
+
+// ユーザーのデッキを取得する関数
+export const getDecksByUserId = (userId: string): MockDeck[] => {
+    return mockDecks.filter(deck => deck.userId === userId);
+};
+
+// デッキIDでデッキを取得する関数
+export const getDeckById = (deckId: string): MockDeck | undefined => {
+    return mockDecks.find(deck => deck.id === deckId);
 };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -35,6 +35,13 @@ export interface GetRoomInput {
     roomId: string;
 }
 
+export interface StartGameInput {
+    roomId: string;
+    currentUser: MockUser
+    // デモ用フラグ
+    isDemo?: boolean;
+}
+
 export interface UpdatePlayerStatusInput {
     roomId: string;
     currentUser: MockUser;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -4,6 +4,12 @@ export interface MockUser {
     isAdmin: boolean;
 }
 
+export interface MockDeck {
+    id: string;
+    name: string;
+    userId: string;
+}
+
 export interface MockRoomPlayer {
     id: string;
     roomId: string;
@@ -12,6 +18,7 @@ export interface MockRoomPlayer {
     pp: number;
     turn: number;
     turnStatus: 'active' | 'ended';
+    selectedDeckId?: string;
 }
 
 export interface MockRoom {
@@ -37,9 +44,19 @@ export interface GetRoomInput {
 
 export interface StartGameInput {
     roomId: string;
-    currentUser: MockUser
+    currentUser: MockUser;
     // デモ用フラグ
     isDemo?: boolean;
+}
+
+export interface SelectDeckInput {
+    roomId: string;
+    currentUser: MockUser;
+    deckId: string;
+}
+
+export interface GetDecksInput {
+    currentUser: MockUser;
 }
 
 export interface UpdatePlayerStatusInput {


### PR DESCRIPTION
Issue
https://github.com/2507-aws-himawari/menkoverse/issues/56

データのカラム追加
選んだデッキのIDを追加したいです
selectedDeckId?: string;

```

export interface MockRoomPlayer {
    id: string;
    roomId: string;
    userId: string;
    hp: number;
    pp: number;
    turn: number;
    turnStatus: 'active' | 'ended';
    selectedDeckId?: string;//new
}

```

やったこと
- 手動でHostがゲーム開始
- デッキを選ぶ

debug動画

https://github.com/user-attachments/assets/2f092b1d-c906-4f53-90df-662370a27bee

