### PR TITLE
フォロワーの召喚を実装

### DIFF
--- a/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { mockApi } from '@/lib/mockApi';
+import { getPlayersByRoomId, getFollowerById } from '@/lib/mockData';
+import type { MockRoom, MockUser, MockBoardCard } from '@/lib/types';
+
+interface BoardDisplayProps {
+    room: MockRoom;
+    currentUser: MockUser;
+    refreshTrigger?: number; // ボードを強制的に更新するためのトリガー
+}
+
+export function BoardDisplay({ room, currentUser, refreshTrigger }: BoardDisplayProps) {
+    const [boards, setBoards] = useState<{ [playerId: string]: MockBoardCard[] }>({});
+    const [loading, setLoading] = useState(true);
+
+    const roomPlayers = getPlayersByRoomId(room.id);
+
+    // ボードデータを取得
+    useEffect(() => {
+        const loadBoards = async () => {
+            try {
+                setLoading(true);
+                const boardData: { [playerId: string]: MockBoardCard[] } = {};
+
+                for (const player of roomPlayers) {
+                    const playerBoard = await mockApi.getBoard({ roomPlayerId: player.id });
+                    boardData[player.id] = playerBoard || [];
+                }
+
+                setBoards(boardData);
+            } catch (error) {
+                console.error('Failed to load boards:', error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadBoards();
+    }, [room.id, refreshTrigger]); // refreshTriggerを依存配列に追加
+
+    if (loading) {
+        return <div>ボードを読み込み中...</div>;
+    }
+
+    return (
+        <div style={{ marginTop: '20px' }}>
+            <h3>バトルフィールド</h3>
+
+            {roomPlayers.map((player) => {
+                const playerBoard = boards[player.id] || [];
+                const isCurrentPlayer = player.userId === currentUser.id;
+
+                return (
+                    <div key={player.id} style={{
+                        marginBottom: '20px',
+                        border: isCurrentPlayer ? '2px solid #007bff' : '1px solid #ccc',
+                        padding: '15px',
+                        borderRadius: '8px',
+                        backgroundColor: isCurrentPlayer ? '#f8f9fa' : '#ffffff'
+                    }}>
+                        <h4>{isCurrentPlayer ? 'あなたのボード' : '相手のボード'}</h4>
+
+                        {playerBoard.length === 0 ? (
+                            <p style={{ color: '#666', fontStyle: 'italic' }}>
+                                フォロワーはいません
+                            </p>
+                        ) : (
+                            <div style={{
+                                display: 'flex',
+                                gap: '10px',
+                                flexWrap: 'wrap',
+                                minHeight: '120px',
+                                alignItems: 'center'
+                            }}>
+                                {playerBoard
+                                    .sort((a, b) => a.position - b.position)
+                                    .map((boardCard) => {
+                                        const follower = getFollowerById(boardCard.cardId);
+                                        if (!follower) return null;
+
+                                        return (
+                                            <div
+                                                key={boardCard.id}
+                                                style={{
+                                                    border: '1px solid #ddd',
+                                                    borderRadius: '8px',
+                                                    padding: '10px',
+                                                    backgroundColor: '#fff',
+                                                    minWidth: '120px',
+                                                    textAlign: 'center',
+                                                    boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+                                                }}
+                                            >
+                                                <div style={{ fontWeight: 'bold', marginBottom: '5px' }}>
+                                                    {follower.name}
+                                                </div>
+                                                <div style={{ fontSize: '12px', color: '#666' }}>
+                                                    コスト: {boardCard.cost}
+                                                </div>
+                                                <div style={{
+                                                    display: 'flex',
+                                                    justifyContent: 'space-between',
+                                                    marginTop: '8px',
+                                                    fontSize: '14px'
+                                                }}>
+                                                    <span style={{ color: '#d32f2f' }}>
+                                                        攻撃: {boardCard.attack}
+                                                    </span>
+                                                    <span style={{ color: '#388e3c' }}>
+                                                        HP: {boardCard.hp}
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+                            </div>
+                        )}
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
@@ -8,7 +8,7 @@ import type { MockRoom, MockUser, MockBoardCard } from '@/lib/types';
 interface BoardDisplayProps {
     room: MockRoom;
     currentUser: MockUser;
-    refreshTrigger?: number; // ボードを強制的に更新するためのトリガー
+    refreshTrigger?: number;
 }
 
 export function BoardDisplay({ room, currentUser, refreshTrigger }: BoardDisplayProps) {
@@ -38,7 +38,7 @@ export function BoardDisplay({ room, currentUser, refreshTrigger }: BoardDisplay
         };
 
         loadBoards();
-    }, [room.id, refreshTrigger]); // refreshTriggerを依存配列に追加
+    }, [room.id, refreshTrigger]);
 
     if (loading) {
         return <div>ボードを読み込み中...</div>;

--- a/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
@@ -36,10 +36,7 @@ export function GameControls({
 
     return (
         <div>
-            <h2>ゲーム進行中</h2>
             <div>
-                <p>参加者: {roomPlayers.length}/2</p>
-
                 {/* 現在のターン情報 */}
                 {activeUser && (
                     <p style={{ fontWeight: 'bold', color: 'blue' }}>

--- a/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
@@ -104,7 +104,6 @@ function ActivePlayerControls({
     return (
         <div style={{ marginTop: '16px' }}>
             <h3>あなたのターンです</h3>
-
             {/* HP減少デモボタン */}
             <div style={{ marginBottom: '12px' }}>
                 <h4>リーダーにダメージ</h4>
@@ -121,41 +120,6 @@ function ActivePlayerControls({
                     )}
                 </div>
             </div>
-
-            {/* PP消費デモボタン */}
-            <div style={{ marginBottom: '12px' }}>
-                <h4>アクション（PP消費）</h4>
-                <button
-                    onClick={() => onConsumePP(1)}
-                    disabled={loading || currentPP < 1}
-                    style={{
-                        marginRight: '8px',
-                        opacity: currentPP < 1 ? 0.5 : 1
-                    }}
-                >
-                    PP-1消費 {currentPP < 1 && '(不足)'}
-                </button>
-                <button
-                    onClick={() => onConsumePP(2)}
-                    disabled={loading || currentPP < 2}
-                    style={{
-                        marginRight: '8px',
-                        opacity: currentPP < 2 ? 0.5 : 1
-                    }}
-                >
-                    PP-2消費 {currentPP < 2 && '(不足)'}
-                </button>
-                <button
-                    onClick={() => onConsumePP(3)}
-                    disabled={loading || currentPP < 3}
-                    style={{
-                        opacity: currentPP < 3 ? 0.5 : 1
-                    }}
-                >
-                    PP-3消費 {currentPP < 3 && '(不足)'}
-                </button>
-            </div>
-
             {/* ターン終了ボタン */}
             <button
                 onClick={onEndTurn}

--- a/frontend/src/app/room/[roomId]/[status]/_components/HandDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/HandDisplay.tsx
@@ -35,17 +35,15 @@ export function HandDisplay({ room, currentUser, onSummonFollower }: HandDisplay
         setNotification(null);
 
         await onSummonFollower(handCardId);
-        await loadHand(); // 手札を再読み込み
+        await loadHand();
         setSummoning(null);
     };
 
-    // エラーアトムからエラーメッセージを監視
     useEffect(() => {
         if (errorFromAtom) {
-            // ボードが満員の場合やPP不足の場合は通知として表示
             if (errorFromAtom.includes('ボードが満員です') || errorFromAtom.includes('PPが不足しています')) {
                 setNotification(errorFromAtom);
-                setTimeout(() => setNotification(null), 3000); // 3秒後に消去
+                setTimeout(() => setNotification(null), 3000);
             } else {
                 setError(errorFromAtom);
             }
@@ -76,7 +74,6 @@ export function HandDisplay({ room, currentUser, onSummonFollower }: HandDisplay
             loadHand();
         }, 5000);
 
-        // ターン開始イベントリスナーを追加
         const handleTurnStart = () => {
             loadHand();
         };

--- a/frontend/src/app/room/[roomId]/[status]/_components/HandDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/HandDisplay.tsx
@@ -2,18 +2,42 @@
 
 import { useState, useEffect } from 'react';
 import { mockApi } from '@/lib/mockApi';
-import { getFollowerById } from '@/lib/mockData';
+import { getFollowerById, getPlayerByUserIdAndRoomId, getPlayersByRoomId } from '@/lib/mockData';
+import { getActivePlayer } from '@/lib/gameLogic';
 import type { MockUser, MockRoom, MockHand } from '@/lib/types';
 
 interface HandDisplayProps {
     room: MockRoom;
     currentUser: MockUser;
+    onSummonFollower?: (handCardId: string) => Promise<void>;
 }
 
-export function HandDisplay({ room, currentUser }: HandDisplayProps) {
+export function HandDisplay({ room, currentUser, onSummonFollower }: HandDisplayProps) {
     const [hand, setHand] = useState<MockHand[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [summoning, setSummoning] = useState<string | null>(null);
+
+    // 現在のプレイヤー情報を取得
+    const currentPlayer = getPlayerByUserIdAndRoomId(currentUser.id, room.id);
+    const activePlayer = getActivePlayer(room);
+    const isActiveUser = activePlayer?.userId === currentUser.id;
+
+    // フォロワー召喚処理
+    const handleSummon = async (handCardId: string) => {
+        if (!onSummonFollower) return;
+
+        try {
+            setSummoning(handCardId);
+            await onSummonFollower(handCardId);
+            await loadHand(); // 手札を再読み込み
+        } catch (error) {
+            console.error('Summon failed:', error);
+            setError(error instanceof Error ? error.message : '召喚に失敗しました');
+        } finally {
+            setSummoning(null);
+        }
+    };
 
     // 手札を取得
     const loadHand = async () => {
@@ -35,10 +59,9 @@ export function HandDisplay({ room, currentUser }: HandDisplayProps) {
     useEffect(() => {
         loadHand();
 
-        // 定期的に手札を更新
         const interval = setInterval(() => {
             loadHand();
-        }, 1000);
+        }, 5000);
 
         // ターン開始イベントリスナーを追加
         const handleTurnStart = () => {
@@ -76,6 +99,9 @@ export function HandDisplay({ room, currentUser }: HandDisplayProps) {
                 <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
                     {hand.map((card) => {
                         const follower = getFollowerById(card.cardId);
+                        const canSummon = isActiveUser && currentPlayer && currentPlayer.pp >= card.cost;
+                        const isSummoning = summoning === card.id;
+
                         return (
                             <div
                                 key={card.id}
@@ -84,7 +110,8 @@ export function HandDisplay({ room, currentUser }: HandDisplayProps) {
                                     borderRadius: '5px',
                                     padding: '8px',
                                     minWidth: '100px',
-                                    backgroundColor: '#f9f9f9'
+                                    backgroundColor: canSummon ? '#f0f8ff' : '#f9f9f9',
+                                    opacity: canSummon ? 1 : 0.7
                                 }}
                             >
                                 <div style={{ fontWeight: 'bold' }}>
@@ -93,6 +120,28 @@ export function HandDisplay({ room, currentUser }: HandDisplayProps) {
                                 <div>コスト: {card.cost}</div>
                                 <div>攻撃: {card.attack}</div>
                                 <div>体力: {card.hp}</div>
+
+                                {onSummonFollower && isActiveUser && (
+                                    <button
+                                        onClick={() => handleSummon(card.id)}
+                                        disabled={!canSummon || isSummoning}
+                                        style={{
+                                            marginTop: '8px',
+                                            width: '100%',
+                                            padding: '4px 8px',
+                                            fontSize: '12px',
+                                            backgroundColor: canSummon ? '#007bff' : '#6c757d',
+                                            color: 'white',
+                                            border: 'none',
+                                            borderRadius: '3px',
+                                            cursor: canSummon ? 'pointer' : 'not-allowed',
+                                            opacity: isSummoning ? 0.6 : 1
+                                        }}
+                                    >
+                                        {isSummoning ? '召喚中...' :
+                                            !canSummon ? `PP不足(${card.cost})` : '召喚'}
+                                    </button>
+                                )}
                             </div>
                         );
                     })}

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -257,22 +257,20 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
                                 </div>
                             );
                         })}
-
-                        {/* 現在のユーザーの手札を表示 */}
-                        <div style={{ marginTop: '20px' }}>
-                            <HandDisplay
-                                room={room}
-                                currentUser={currentUser}
-                                onSummonFollower={handleSummonFollower}
-                            />
-                        </div>
-
                         {/* バトルフィールド（ボード）を表示 */}
                         <div style={{ marginTop: '20px' }}>
                             <BoardDisplay
                                 room={room}
                                 currentUser={currentUser}
                                 refreshTrigger={boardRefreshTrigger}
+                            />
+                        </div>
+                        {/* 現在のユーザーの手札を表示 */}
+                        <div style={{ marginTop: '20px' }}>
+                            <HandDisplay
+                                room={room}
+                                currentUser={currentUser}
+                                onSummonFollower={handleSummonFollower}
                             />
                         </div>
                     </div>

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -131,17 +131,6 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
                                             )}
                                         </p>
                                     )}
-
-                                    {room.status === 'playing' && (
-                                        <p >
-                                            [DEBUG] デッキ: {selectedDeck ? selectedDeck.name : '未選択'}
-                                            {player.selectedDeckId && (
-                                                <span style={{ marginLeft: '5px' }}>
-                                                    (ID: {player.selectedDeckId})
-                                                </span>
-                                            )}
-                                        </p>
-                                    )}
                                 </div>
                             </div>
                         </div>
@@ -238,25 +227,6 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
 
                 {room.status === 'playing' && (
                     <div>
-                        <h4>
-                            [DEBUG] デッキ選択状況
-                        </h4>
-                        {roomPlayers.map((player, index) => {
-                            const user = getUserById(player.userId, mockUsers);
-                            const selectedDeck = player.selectedDeckId ? getDeckById(player.selectedDeckId) : null;
-                            return (
-                                <div key={player.id}>
-                                    <strong>{user?.name}</strong>: {' '}
-                                    {selectedDeck ? (
-                                        <span style={{ color: '#28a745' }}>
-                                            {selectedDeck.name} (ID: {player.selectedDeckId})
-                                        </span>
-                                    ) : (
-                                        <span style={{ color: '#dc3545' }}>デッキ未選択</span>
-                                    )}
-                                </div>
-                            );
-                        })}
                         {/* バトルフィールド（ボード）を表示 */}
                         <div style={{ marginTop: '20px' }}>
                             <BoardDisplay

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -9,6 +9,8 @@ import { currentUserAtom } from '@/lib/atoms';
 import { useState } from 'react';
 import { DeckSelector } from './DeckSelector';
 import { HandDisplay } from './HandDisplay';
+import { BoardDisplay } from './BoardDisplay';
+import { useGameActions } from '../_hooks/useGameActions';
 
 interface RoomDisplayProps {
     room: MockRoom;
@@ -21,6 +23,17 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
     const [currentUser] = useAtom(currentUserAtom);
     const [isStartingGame, setIsStartingGame] = useState(false);
     const [, forceUpdate] = useState({});
+    const [boardRefreshTrigger, setBoardRefreshTrigger] = useState(0);
+
+    // ゲームアクションフック
+    const { handleSummonFollower: originalHandleSummonFollower } = useGameActions();
+
+    // フォロワー召喚後にボードを更新
+    const handleSummonFollower = async (handCardId: string) => {
+        await originalHandleSummonFollower(handCardId);
+        setBoardRefreshTrigger(prev => prev + 1);
+        refreshData();
+    };
 
     const refreshData = () => {
         forceUpdate({});
@@ -247,7 +260,20 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
 
                         {/* 現在のユーザーの手札を表示 */}
                         <div style={{ marginTop: '20px' }}>
-                            <HandDisplay room={room} currentUser={currentUser} />
+                            <HandDisplay
+                                room={room}
+                                currentUser={currentUser}
+                                onSummonFollower={handleSummonFollower}
+                            />
+                        </div>
+
+                        {/* バトルフィールド（ボード）を表示 */}
+                        <div style={{ marginTop: '20px' }}>
+                            <BoardDisplay
+                                room={room}
+                                currentUser={currentUser}
+                                refreshTrigger={boardRefreshTrigger}
+                            />
                         </div>
                     </div>
                 )}

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -17,7 +17,6 @@ interface RoomDisplayProps {
 }
 
 export function RoomDisplay({ room }: RoomDisplayProps) {
-    // プレイヤー情報を取得
     const roomPlayers = getPlayersByRoomId(room.id);
     const router = useRouter();
     const [currentUser] = useAtom(currentUserAtom);
@@ -25,7 +24,6 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
     const [, forceUpdate] = useState({});
     const [boardRefreshTrigger, setBoardRefreshTrigger] = useState(0);
 
-    // ゲームアクションフック
     const { handleSummonFollower: originalHandleSummonFollower } = useGameActions();
 
     // フォロワー召喚後にボードを更新

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
@@ -75,9 +75,21 @@ export function useGameActions() {
     };
 
     const handleSummonFollower = async (handCardId: string) => {
-        await handleWithLoading(async () => {
-            await gameActions.handleSummonFollower(currentUser, handCardId);
-        });
+        try {
+            setLoading(true);
+            setError(null);
+            const errorMessage = await gameActions.handleSummonFollower(currentUser, handCardId);
+
+            if (errorMessage) {
+                // エラーメッセージがある場合はエラーとして設定
+                setError(errorMessage);
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : '召喚に失敗しました';
+            setError(errorMessage);
+        } finally {
+            setLoading(false);
+        }
     };
 
     return {

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
@@ -74,6 +74,12 @@ export function useGameActions() {
         });
     };
 
+    const handleSummonFollower = async (handCardId: string) => {
+        await handleWithLoading(async () => {
+            await gameActions.handleSummonFollower(currentUser, handCardId);
+        });
+    };
+
     return {
         handleStartTurn,
         handleEndTurn,
@@ -82,5 +88,6 @@ export function useGameActions() {
         handleDamagePlayer,
         handleDamageToSelf,
         handleDamageToOpponent,
+        handleSummonFollower,
     };
 }

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
@@ -96,18 +96,24 @@ export function useGameActionsCore(roomId: string | null) {
     };
 
     // フォロワーを召喚
-    const handleSummonFollower = async (currentUser: MockUser, handCardId: string): Promise<void> => {
-        if (!roomId) return;
+    const handleSummonFollower = async (currentUser: MockUser, handCardId: string): Promise<string | null> => {
+        if (!roomId) return '部屋が見つかりません';
 
         try {
-            await mockApi.summonFollower({
+            const result = await mockApi.summonFollower({
                 roomId,
                 currentUser,
                 handCardId
             });
-            await updateRoomCache(roomId);
+
+            if (result.success) {
+                await updateRoomCache(roomId);
+                return null; // 成功の場合はnullを返す
+            } else {
+                return result.message || '召喚に失敗しました'; // エラーメッセージを返す
+            }
         } catch (error) {
-            throw error;
+            return error instanceof Error ? error.message : '召喚に失敗しました';
         }
     };
 

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
@@ -95,6 +95,22 @@ export function useGameActionsCore(roomId: string | null) {
         await handleDamagePlayer(currentUser, opponentUserId, damage);
     };
 
+    // フォロワーを召喚
+    const handleSummonFollower = async (currentUser: MockUser, handCardId: string): Promise<void> => {
+        if (!roomId) return;
+
+        try {
+            await mockApi.summonFollower({
+                roomId,
+                currentUser,
+                handCardId
+            });
+            await updateRoomCache(roomId);
+        } catch (error) {
+            throw error;
+        }
+    };
+
     return {
         handleStartTurn,
         handleEndTurn,
@@ -103,5 +119,6 @@ export function useGameActionsCore(roomId: string | null) {
         handleDamagePlayer,
         handleDamageToSelf,
         handleDamageToOpponent,
+        handleSummonFollower,
     };
 }

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useRoom.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useRoom.ts
@@ -2,7 +2,7 @@ import useSWR from 'swr';
 import { mockApi } from '@/lib/mockApi';
 import type { MockRoom } from '@/lib/types';
 
-//特定の部屋の情報を取得するSWR
+//特定の部屋の情報を取得する
 export function useRoom(roomId: string | null) {
     const { data, error, isLoading, mutate } = useSWR<MockRoom | null, Error>(
         roomId ? `/api/rooms/${roomId}` : null,

--- a/frontend/src/lib/mockApi.ts
+++ b/frontend/src/lib/mockApi.ts
@@ -14,11 +14,8 @@ import {
     getDeckById,
     getDeckCardsByDeckId,
     getHandsByRoomPlayerId,
-    updateMockRoomPlayers,
-    updateMockHands,
     getFollowerById,
     getBoardByRoomPlayerId,
-    updateMockBoard,
     mockBoard
 } from './mockData';
 import type {
@@ -344,7 +341,6 @@ export const mockApi = {
             }
         } catch (error) {
             console.error(`Failed to draw card at turn start for player ${input.currentUser.name}:`, error);
-            // ドローに失敗してもターン開始は継続
         }
 
         return player;
@@ -411,7 +407,7 @@ export const mockApi = {
         return room;
     },
 
-    // PP消費（デモ用）
+    // PP消費
     consumePP: async (input: ConsumePPInput): Promise<MockRoomPlayer | null> => {
         const room = getRoomById(input.roomId);
         if (!room) return null;

--- a/frontend/src/lib/mockApi.ts
+++ b/frontend/src/lib/mockApi.ts
@@ -586,6 +586,12 @@ export const mockApi = {
         return hands;
     },
 
+    // プレイヤーのボードを取得
+    getBoard: async (input: { roomPlayerId: string }): Promise<MockBoardCard[]> => {
+        const boards = getBoardByRoomPlayerId(input.roomPlayerId);
+        return boards;
+    },
+
     // フォロワーを召喚
     summonFollower: async (input: SummonFollowerInput): Promise<MockBoardCard> => {
         const room = getRoomById(input.roomId);

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -1,5 +1,5 @@
 import { GAME_CONSTANTS } from './constants';
-import type { MockUser, MockRoom, MockRoomPlayer, MockDeck, MockDeckCard, MockHand, MockFollower } from './types';
+import type { MockUser, MockRoom, MockRoomPlayer, MockDeck, MockDeckCard, MockHand, MockFollower, MockBoardCard } from './types';
 
 // ユーザー
 export const mockUsers: MockUser[] = [
@@ -140,7 +140,12 @@ export let mockDeckCards: MockDeckCard[] = [
 
 // 手札（プレイヤーが現在持っているカード）
 export let mockHands: MockHand[] = [
-    // 現在は空 - ドロー処理で追加される
+
+];
+
+// ボード（場に出ているフォロワー）
+export let mockBoard: MockBoardCard[] = [
+
 ];
 
 // フォロワー（カードの基本情報）
@@ -200,6 +205,16 @@ export const getHandsByRoomPlayerId = (roomPlayerId: string): MockHand[] => {
 // 手札を更新する関数
 export const updateMockHands = (newHands: MockHand[]) => {
     mockHands = newHands;
+};
+
+// プレイヤーのボードを取得する関数
+export const getBoardByRoomPlayerId = (roomPlayerId: string): MockBoardCard[] => {
+    return mockBoard.filter(board => board.roomPlayerId === roomPlayerId);
+};
+
+// ボードを更新する関数
+export const updateMockBoard = (newBoard: MockBoardCard[]) => {
+    mockBoard = newBoard;
 };
 
 // フォロワーIDでフォロワー情報を取得する関数

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -162,11 +162,6 @@ export const mockFollowers: MockFollower[] = [
     { id: 'card10', name: 'エンシェントドラゴン', cost: 6, attack: 4, hp: 7 },
 ];
 
-// プレイヤーデータを更新する関数
-export const updateMockRoomPlayers = (newPlayers: MockRoomPlayer[]) => {
-    mockRoomPlayers = newPlayers;
-};
-
 // モックデータから部屋を検索する関数
 export const getRoomById = (roomId: string): MockRoom | undefined => {
     return mockRooms.find(r => r.id === roomId);
@@ -202,19 +197,9 @@ export const getHandsByRoomPlayerId = (roomPlayerId: string): MockHand[] => {
     return mockHands.filter(hand => hand.roomPlayerId === roomPlayerId);
 };
 
-// 手札を更新する関数
-export const updateMockHands = (newHands: MockHand[]) => {
-    mockHands = newHands;
-};
-
 // プレイヤーのボードを取得する関数
 export const getBoardByRoomPlayerId = (roomPlayerId: string): MockBoardCard[] => {
     return mockBoard.filter(board => board.roomPlayerId === roomPlayerId);
-};
-
-// ボードを更新する関数
-export const updateMockBoard = (newBoard: MockBoardCard[]) => {
-    mockBoard = newBoard;
 };
 
 // フォロワーIDでフォロワー情報を取得する関数

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -144,3 +144,10 @@ export interface SummonFollowerInput {
     currentUser: MockUser;
     handCardId: string;
 }
+
+export interface SummonFollowerResult {
+    success: boolean;
+    boardCard?: MockBoardCard;
+    message?: string;
+    reason?: 'board_full' | 'insufficient_pp' | 'invalid_card' | 'not_your_turn' | 'unknown';
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -33,6 +33,16 @@ export interface MockHand {
     hp: number;
 }
 
+export interface MockBoardCard {
+    id: string;
+    roomPlayerId: string;
+    cardId: string;
+    cost: number;
+    attack: number;
+    hp: number;
+    position: number; // ボード上の位置 (0-6)
+}
+
 export interface MockRoomPlayer {
     id: string;
     roomId: string;
@@ -127,4 +137,10 @@ export interface DrawCardsInput {
 export interface GetHandInput {
     roomId: string;
     currentUser: MockUser;
+}
+
+export interface SummonFollowerInput {
+    roomId: string;
+    currentUser: MockUser;
+    handCardId: string;
 }


### PR DESCRIPTION
## 概要
フォロワーの召喚を実装する
## 該当Issue
https://github.com/2507-aws-himawari/menkoverse/issues/29
https://github.com/2507-aws-himawari/menkoverse/issues/33

## やった・できること
- PPからフォロワーを召喚
- 場の召喚制限（5体）
- 不要な部分削除


ボードに何体いるか確認したくてBoardCard に以下を追加

position: number;
## でも


https://github.com/user-attachments/assets/097d47d9-30c4-49dc-b20b-c39a4e2a8d8c




