### PR TITLE
フォロワーの攻撃処理を追加

### DIFF
--- a/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { mockApi } from '@/lib/mockApi';
+import { getPlayersByRoomId, getFollowerById } from '@/lib/mockData';
+import type { MockRoom, MockUser, MockBoardCard } from '@/lib/types';
+
+interface BoardDisplayProps {
+    room: MockRoom;
+    currentUser: MockUser;
+    refreshTrigger?: number; // ボードを強制的に更新するためのトリガー
+}
+
+export function BoardDisplay({ room, currentUser, refreshTrigger }: BoardDisplayProps) {
+    const [boards, setBoards] = useState<{ [playerId: string]: MockBoardCard[] }>({});
+    const [loading, setLoading] = useState(true);
+
+    const roomPlayers = getPlayersByRoomId(room.id);
+
+    // ボードデータを取得
+    useEffect(() => {
+        const loadBoards = async () => {
+            try {
+                setLoading(true);
+                const boardData: { [playerId: string]: MockBoardCard[] } = {};
+
+                for (const player of roomPlayers) {
+                    const playerBoard = await mockApi.getBoard({ roomPlayerId: player.id });
+                    boardData[player.id] = playerBoard || [];
+                }
+
+                setBoards(boardData);
+            } catch (error) {
+                console.error('Failed to load boards:', error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadBoards();
+    }, [room.id, refreshTrigger]); // refreshTriggerを依存配列に追加
+
+    if (loading) {
+        return <div>ボードを読み込み中...</div>;
+    }
+
+    return (
+        <div style={{ marginTop: '20px' }}>
+            <h3>バトルフィールド</h3>
+
+            {roomPlayers.map((player) => {
+                const playerBoard = boards[player.id] || [];
+                const isCurrentPlayer = player.userId === currentUser.id;
+
+                return (
+                    <div key={player.id} style={{
+                        marginBottom: '20px',
+                        border: isCurrentPlayer ? '2px solid #007bff' : '1px solid #ccc',
+                        padding: '15px',
+                        borderRadius: '8px',
+                        backgroundColor: isCurrentPlayer ? '#f8f9fa' : '#ffffff'
+                    }}>
+                        <h4>{isCurrentPlayer ? 'あなたのボード' : '相手のボード'}</h4>
+
+                        {playerBoard.length === 0 ? (
+                            <p style={{ color: '#666', fontStyle: 'italic' }}>
+                                フォロワーはいません
+                            </p>
+                        ) : (
+                            <div style={{
+                                display: 'flex',
+                                gap: '10px',
+                                flexWrap: 'wrap',
+                                minHeight: '120px',
+                                alignItems: 'center'
+                            }}>
+                                {playerBoard
+                                    .sort((a, b) => a.position - b.position)
+                                    .map((boardCard) => {
+                                        const follower = getFollowerById(boardCard.cardId);
+                                        if (!follower) return null;
+
+                                        return (
+                                            <div
+                                                key={boardCard.id}
+                                                style={{
+                                                    border: '1px solid #ddd',
+                                                    borderRadius: '8px',
+                                                    padding: '10px',
+                                                    backgroundColor: '#fff',
+                                                    minWidth: '120px',
+                                                    textAlign: 'center',
+                                                    boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+                                                }}
+                                            >
+                                                <div style={{ fontWeight: 'bold', marginBottom: '5px' }}>
+                                                    {follower.name}
+                                                </div>
+                                                <div style={{ fontSize: '12px', color: '#666' }}>
+                                                    コスト: {boardCard.cost}
+                                                </div>
+                                                <div style={{
+                                                    display: 'flex',
+                                                    justifyContent: 'space-between',
+                                                    marginTop: '8px',
+                                                    fontSize: '14px'
+                                                }}>
+                                                    <span style={{ color: '#d32f2f' }}>
+                                                        攻撃: {boardCard.attack}
+                                                    </span>
+                                                    <span style={{ color: '#388e3c' }}>
+                                                        HP: {boardCard.hp}
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+                            </div>
+                        )}
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
@@ -3,19 +3,29 @@
 import { useState, useEffect } from 'react';
 import { mockApi } from '@/lib/mockApi';
 import { getPlayersByRoomId, getFollowerById } from '@/lib/mockData';
+import { getActivePlayer } from '@/lib/gameLogic';
 import type { MockRoom, MockUser, MockBoardCard } from '@/lib/types';
 
 interface BoardDisplayProps {
     room: MockRoom;
     currentUser: MockUser;
     refreshTrigger?: number;
+    onAttackWithFollower?: (
+        attackerBoardCardId: string,
+        targetType: 'follower' | 'player',
+        targetId: string
+    ) => Promise<void>;
 }
 
-export function BoardDisplay({ room, currentUser, refreshTrigger }: BoardDisplayProps) {
+export function BoardDisplay({ room, currentUser, refreshTrigger, onAttackWithFollower }: BoardDisplayProps) {
     const [boards, setBoards] = useState<{ [playerId: string]: MockBoardCard[] }>({});
     const [loading, setLoading] = useState(true);
+    const [attackingFollowerId, setAttackingFollowerId] = useState<string | null>(null);
+    const [selectingTarget, setSelectingTarget] = useState(false);
 
     const roomPlayers = getPlayersByRoomId(room.id);
+    const activePlayer = getActivePlayer(room);
+    const isActiveUser = activePlayer?.userId === currentUser.id;
 
     // ボードデータを取得
     useEffect(() => {
@@ -39,6 +49,29 @@ export function BoardDisplay({ room, currentUser, refreshTrigger }: BoardDisplay
 
         loadBoards();
     }, [room.id, refreshTrigger]);
+
+    // 攻撃処理関数
+    const handleStartAttack = (attackerCardId: string) => {
+        setAttackingFollowerId(attackerCardId);
+        setSelectingTarget(true);
+    };
+
+    const handleCancelAttack = () => {
+        setAttackingFollowerId(null);
+        setSelectingTarget(false);
+    };
+
+    const handleAttackTarget = async (targetType: 'follower' | 'player', targetId: string) => {
+        if (!attackingFollowerId || !onAttackWithFollower) return;
+
+        try {
+            await onAttackWithFollower(attackingFollowerId, targetType, targetId);
+            handleCancelAttack();
+        } catch (error) {
+            console.error('Attack failed:', error);
+            handleCancelAttack();
+        }
+    };
 
     if (loading) {
         return <div>ボードを読み込み中...</div>;
@@ -80,17 +113,27 @@ export function BoardDisplay({ room, currentUser, refreshTrigger }: BoardDisplay
                                         const follower = getFollowerById(boardCard.cardId);
                                         if (!follower) return null;
 
+                                        const canAttack = isCurrentPlayer && isActiveUser && boardCard.canAttack;
+                                        const isAttacking = attackingFollowerId === boardCard.id;
+                                        const isTargetable = selectingTarget && !isCurrentPlayer;
+
                                         return (
                                             <div
                                                 key={boardCard.id}
                                                 style={{
-                                                    border: '1px solid #ddd',
+                                                    border: isAttacking ? '3px solid #ff9800' : isTargetable ? '2px solid #f44336' : '1px solid #ddd',
                                                     borderRadius: '8px',
                                                     padding: '10px',
-                                                    backgroundColor: '#fff',
+                                                    backgroundColor: isTargetable ? '#ffebee' : '#fff',
                                                     minWidth: '120px',
                                                     textAlign: 'center',
-                                                    boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+                                                    boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                                                    cursor: isTargetable ? 'pointer' : 'default'
+                                                }}
+                                                onClick={() => {
+                                                    if (isTargetable) {
+                                                        handleAttackTarget('follower', boardCard.id);
+                                                    }
                                                 }}
                                             >
                                                 <div style={{ fontWeight: 'bold', marginBottom: '5px' }}>
@@ -112,6 +155,72 @@ export function BoardDisplay({ room, currentUser, refreshTrigger }: BoardDisplay
                                                         HP: {boardCard.hp}
                                                     </span>
                                                 </div>
+
+                                                {/* 攻撃可能状態の表示 */}
+                                                {canAttack && !selectingTarget && (
+                                                    <div style={{ marginTop: '8px' }}>
+                                                        <button
+                                                            onClick={() => handleStartAttack(boardCard.id)}
+                                                            style={{
+                                                                backgroundColor: '#4caf50',
+                                                                color: 'white',
+                                                                border: 'none',
+                                                                borderRadius: '4px',
+                                                                padding: '4px 8px',
+                                                                fontSize: '12px',
+                                                                cursor: 'pointer'
+                                                            }}
+                                                        >
+                                                            攻撃
+                                                        </button>
+                                                    </div>
+                                                )}
+
+                                                {/* 攻撃中の表示 */}
+                                                {isAttacking && (
+                                                    <div style={{ marginTop: '8px' }}>
+                                                        <div style={{ fontSize: '12px', color: '#ff9800', marginBottom: '4px' }}>
+                                                            ターゲットを選択
+                                                        </div>
+                                                        <button
+                                                            onClick={handleCancelAttack}
+                                                            style={{
+                                                                backgroundColor: '#f44336',
+                                                                color: 'white',
+                                                                border: 'none',
+                                                                borderRadius: '4px',
+                                                                padding: '4px 8px',
+                                                                fontSize: '12px',
+                                                                cursor: 'pointer'
+                                                            }}
+                                                        >
+                                                            キャンセル
+                                                        </button>
+                                                    </div>
+                                                )}
+
+                                                {/* 攻撃不可能状態の表示 */}
+                                                {isCurrentPlayer && isActiveUser && !boardCard.canAttack && (
+                                                    <div style={{
+                                                        marginTop: '8px',
+                                                        fontSize: '10px',
+                                                        color: '#999'
+                                                    }}>
+                                                        攻撃済み
+                                                    </div>
+                                                )}
+
+                                                {/* ターゲット可能状態の表示 */}
+                                                {isTargetable && (
+                                                    <div style={{
+                                                        marginTop: '8px',
+                                                        fontSize: '12px',
+                                                        color: '#f44336',
+                                                        fontWeight: 'bold'
+                                                    }}>
+                                                        クリックして攻撃
+                                                    </div>
+                                                )}
                                             </div>
                                         );
                                     })}
@@ -120,6 +229,64 @@ export function BoardDisplay({ room, currentUser, refreshTrigger }: BoardDisplay
                     </div>
                 );
             })}
+
+            {/* 攻撃対象選択時の追加UI */}
+            {selectingTarget && (
+                <div style={{
+                    marginTop: '20px',
+                    padding: '15px',
+                    backgroundColor: '#fff3e0',
+                    border: '2px solid #ff9800',
+                    borderRadius: '8px'
+                }}>
+                    <h4 style={{ color: '#e65100', marginBottom: '10px' }}>
+                        攻撃対象を選択してください
+                    </h4>
+                    <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                        {roomPlayers
+                            .filter(player => player.userId !== currentUser.id)
+                            .map((player) => (
+                                <button
+                                    key={`player-${player.id}`}
+                                    onClick={() => handleAttackTarget('player', player.userId)}
+                                    style={{
+                                        backgroundColor: '#f44336',
+                                        color: 'white',
+                                        border: 'none',
+                                        borderRadius: '8px',
+                                        padding: '10px 15px',
+                                        fontSize: '14px',
+                                        cursor: 'pointer',
+                                        fontWeight: 'bold'
+                                    }}
+                                >
+                                    相手プレイヤーを攻撃 (HP: {player.hp})
+                                </button>
+                            ))}
+                        <button
+                            onClick={handleCancelAttack}
+                            style={{
+                                backgroundColor: '#9e9e9e',
+                                color: 'white',
+                                border: 'none',
+                                borderRadius: '8px',
+                                padding: '10px 15px',
+                                fontSize: '14px',
+                                cursor: 'pointer'
+                            }}
+                        >
+                            キャンセル
+                        </button>
+                    </div>
+                    <p style={{
+                        marginTop: '10px',
+                        fontSize: '12px',
+                        color: '#666'
+                    }}>
+                        相手のフォロワーをクリックするか、上のボタンで相手プレイヤーを直接攻撃できます。
+                    </p>
+                </div>
+            )}
         </div>
     );
 }

--- a/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { mockApi } from '@/lib/mockApi';
 import { getPlayersByRoomId, getFollowerById } from '@/lib/mockData';
-import { getActivePlayer } from '@/lib/gameLogic';
+import { getActivePlayer, canFollowerAttack, hasFollowerAttackedThisTurn } from '@/lib/gameLogic';
 import type { MockRoom, MockUser, MockBoardCard } from '@/lib/types';
 
 interface BoardDisplayProps {
@@ -156,8 +156,7 @@ export function BoardDisplay({ room, currentUser, refreshTrigger, onAttackWithFo
                                         if (!follower) return null;
 
                                         const canAttack = isCurrentPlayer && isActiveUser &&
-                                            boardCard.summonedTurn !== activePlayer?.turn &&
-                                            !boardCard.hasAttackedThisTurn;
+                                            canFollowerAttack(boardCard, activePlayer?.turn || 0);
                                         const isAttacking = attackingFollowerId === boardCard.id;
                                         const isTargetable = selectingTarget && !isCurrentPlayer;
 
@@ -256,10 +255,8 @@ export function BoardDisplay({ room, currentUser, refreshTrigger, onAttackWithFo
                                                     </div>
                                                 )}
                                                 {/* 攻撃不可能状態の表示 */}
-                                                {isCurrentPlayer && isActiveUser && (
-                                                    boardCard.summonedTurn === activePlayer?.turn ||
-                                                    boardCard.hasAttackedThisTurn
-                                                ) && (
+                                                {isCurrentPlayer && isActiveUser &&
+                                                    !canFollowerAttack(boardCard, activePlayer?.turn || 0) && (
                                                         <div style={{
                                                             marginTop: '8px',
                                                             fontSize: '10px',

--- a/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/BoardDisplay.tsx
@@ -8,7 +8,7 @@ import type { MockRoom, MockUser, MockBoardCard } from '@/lib/types';
 interface BoardDisplayProps {
     room: MockRoom;
     currentUser: MockUser;
-    refreshTrigger?: number; // ボードを強制的に更新するためのトリガー
+    refreshTrigger?: number;
 }
 
 export function BoardDisplay({ room, currentUser, refreshTrigger }: BoardDisplayProps) {
@@ -38,7 +38,7 @@ export function BoardDisplay({ room, currentUser, refreshTrigger }: BoardDisplay
         };
 
         loadBoards();
-    }, [room.id, refreshTrigger]); // refreshTriggerを依存配列に追加
+    }, [room.id, refreshTrigger]);
 
     if (loading) {
         return <div>ボードを読み込み中...</div>;

--- a/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
@@ -36,10 +36,7 @@ export function GameControls({
 
     return (
         <div>
-            <h2>ゲーム進行中</h2>
             <div>
-                <p>参加者: {roomPlayers.length}/2</p>
-
                 {/* 現在のターン情報 */}
                 {activeUser && (
                     <p style={{ fontWeight: 'bold', color: 'blue' }}>

--- a/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
@@ -99,25 +99,7 @@ function ActivePlayerControls({
     const opponentPlayer = roomPlayers.find(p => p.userId !== currentUser.id);
 
     return (
-        <div style={{ marginTop: '16px' }}>
-            <h3>あなたのターンです</h3>
-            {/* HP減少デモボタン */}
-            <div style={{ marginBottom: '12px' }}>
-                <h4>リーダーにダメージ</h4>
-                <div style={{ display: 'flex', gap: '8px' }}>
-                    {onDamageToSelf && (
-                        <button onClick={() => onDamageToSelf(1)} disabled={loading}>
-                            自分に1ダメージ
-                        </button>
-                    )}
-                    {opponentPlayer && onDamageToOpponent && (
-                        <button onClick={() => onDamageToOpponent(opponentPlayer.userId, 1)} disabled={loading}>
-                            相手に1ダメージ
-                        </button>
-                    )}
-                </div>
-            </div>
-            {/* ターン終了ボタン */}
+        <div >
             <button
                 onClick={onEndTurn}
                 disabled={loading}

--- a/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
@@ -104,7 +104,6 @@ function ActivePlayerControls({
     return (
         <div style={{ marginTop: '16px' }}>
             <h3>あなたのターンです</h3>
-
             {/* HP減少デモボタン */}
             <div style={{ marginBottom: '12px' }}>
                 <h4>リーダーにダメージ</h4>
@@ -121,41 +120,6 @@ function ActivePlayerControls({
                     )}
                 </div>
             </div>
-
-            {/* PP消費デモボタン */}
-            <div style={{ marginBottom: '12px' }}>
-                <h4>アクション（PP消費）</h4>
-                <button
-                    onClick={() => onConsumePP(1)}
-                    disabled={loading || currentPP < 1}
-                    style={{
-                        marginRight: '8px',
-                        opacity: currentPP < 1 ? 0.5 : 1
-                    }}
-                >
-                    PP-1消費 {currentPP < 1 && '(不足)'}
-                </button>
-                <button
-                    onClick={() => onConsumePP(2)}
-                    disabled={loading || currentPP < 2}
-                    style={{
-                        marginRight: '8px',
-                        opacity: currentPP < 2 ? 0.5 : 1
-                    }}
-                >
-                    PP-2消費 {currentPP < 2 && '(不足)'}
-                </button>
-                <button
-                    onClick={() => onConsumePP(3)}
-                    disabled={loading || currentPP < 3}
-                    style={{
-                        opacity: currentPP < 3 ? 0.5 : 1
-                    }}
-                >
-                    PP-3消費 {currentPP < 3 && '(不足)'}
-                </button>
-            </div>
-
             {/* ターン終了ボタン */}
             <button
                 onClick={onEndTurn}

--- a/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/GameControls.tsx
@@ -37,13 +37,6 @@ export function GameControls({
     return (
         <div>
             <div>
-                {/* 現在のターン情報 */}
-                {activeUser && (
-                    <p style={{ fontWeight: 'bold', color: 'blue' }}>
-                        現在のターン: {activeUser.name}
-                    </p>
-                )}
-
                 {/* アクティブプレイヤーのみに表示される操作 */}
                 {isActiveUser ? (
                     <ActivePlayerControls

--- a/frontend/src/app/room/[roomId]/[status]/_components/HandDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/HandDisplay.tsx
@@ -35,17 +35,15 @@ export function HandDisplay({ room, currentUser, onSummonFollower }: HandDisplay
         setNotification(null);
 
         await onSummonFollower(handCardId);
-        await loadHand(); // 手札を再読み込み
+        await loadHand();
         setSummoning(null);
     };
 
-    // エラーアトムからエラーメッセージを監視
     useEffect(() => {
         if (errorFromAtom) {
-            // ボードが満員の場合やPP不足の場合は通知として表示
             if (errorFromAtom.includes('ボードが満員です') || errorFromAtom.includes('PPが不足しています')) {
                 setNotification(errorFromAtom);
-                setTimeout(() => setNotification(null), 3000); // 3秒後に消去
+                setTimeout(() => setNotification(null), 3000);
             } else {
                 setError(errorFromAtom);
             }
@@ -76,7 +74,6 @@ export function HandDisplay({ room, currentUser, onSummonFollower }: HandDisplay
             loadHand();
         }, 5000);
 
-        // ターン開始イベントリスナーを追加
         const handleTurnStart = () => {
             loadHand();
         };

--- a/frontend/src/app/room/[roomId]/[status]/_components/HandDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/HandDisplay.tsx
@@ -2,18 +2,42 @@
 
 import { useState, useEffect } from 'react';
 import { mockApi } from '@/lib/mockApi';
-import { getFollowerById } from '@/lib/mockData';
+import { getFollowerById, getPlayerByUserIdAndRoomId, getPlayersByRoomId } from '@/lib/mockData';
+import { getActivePlayer } from '@/lib/gameLogic';
 import type { MockUser, MockRoom, MockHand } from '@/lib/types';
 
 interface HandDisplayProps {
     room: MockRoom;
     currentUser: MockUser;
+    onSummonFollower?: (handCardId: string) => Promise<void>;
 }
 
-export function HandDisplay({ room, currentUser }: HandDisplayProps) {
+export function HandDisplay({ room, currentUser, onSummonFollower }: HandDisplayProps) {
     const [hand, setHand] = useState<MockHand[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [summoning, setSummoning] = useState<string | null>(null);
+
+    // 現在のプレイヤー情報を取得
+    const currentPlayer = getPlayerByUserIdAndRoomId(currentUser.id, room.id);
+    const activePlayer = getActivePlayer(room);
+    const isActiveUser = activePlayer?.userId === currentUser.id;
+
+    // フォロワー召喚処理
+    const handleSummon = async (handCardId: string) => {
+        if (!onSummonFollower) return;
+
+        try {
+            setSummoning(handCardId);
+            await onSummonFollower(handCardId);
+            await loadHand(); // 手札を再読み込み
+        } catch (error) {
+            console.error('Summon failed:', error);
+            setError(error instanceof Error ? error.message : '召喚に失敗しました');
+        } finally {
+            setSummoning(null);
+        }
+    };
 
     // 手札を取得
     const loadHand = async () => {
@@ -35,10 +59,9 @@ export function HandDisplay({ room, currentUser }: HandDisplayProps) {
     useEffect(() => {
         loadHand();
 
-        // 定期的に手札を更新
         const interval = setInterval(() => {
             loadHand();
-        }, 1000);
+        }, 5000);
 
         // ターン開始イベントリスナーを追加
         const handleTurnStart = () => {
@@ -76,6 +99,9 @@ export function HandDisplay({ room, currentUser }: HandDisplayProps) {
                 <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
                     {hand.map((card) => {
                         const follower = getFollowerById(card.cardId);
+                        const canSummon = isActiveUser && currentPlayer && currentPlayer.pp >= card.cost;
+                        const isSummoning = summoning === card.id;
+
                         return (
                             <div
                                 key={card.id}
@@ -84,7 +110,8 @@ export function HandDisplay({ room, currentUser }: HandDisplayProps) {
                                     borderRadius: '5px',
                                     padding: '8px',
                                     minWidth: '100px',
-                                    backgroundColor: '#f9f9f9'
+                                    backgroundColor: canSummon ? '#f0f8ff' : '#f9f9f9',
+                                    opacity: canSummon ? 1 : 0.7
                                 }}
                             >
                                 <div style={{ fontWeight: 'bold' }}>
@@ -93,6 +120,28 @@ export function HandDisplay({ room, currentUser }: HandDisplayProps) {
                                 <div>コスト: {card.cost}</div>
                                 <div>攻撃: {card.attack}</div>
                                 <div>体力: {card.hp}</div>
+
+                                {onSummonFollower && isActiveUser && (
+                                    <button
+                                        onClick={() => handleSummon(card.id)}
+                                        disabled={!canSummon || isSummoning}
+                                        style={{
+                                            marginTop: '8px',
+                                            width: '100%',
+                                            padding: '4px 8px',
+                                            fontSize: '12px',
+                                            backgroundColor: canSummon ? '#007bff' : '#6c757d',
+                                            color: 'white',
+                                            border: 'none',
+                                            borderRadius: '3px',
+                                            cursor: canSummon ? 'pointer' : 'not-allowed',
+                                            opacity: isSummoning ? 0.6 : 1
+                                        }}
+                                    >
+                                        {isSummoning ? '召喚中...' :
+                                            !canSummon ? `PP不足(${card.cost})` : '召喚'}
+                                    </button>
+                                )}
                             </div>
                         );
                     })}

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -257,22 +257,20 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
                                 </div>
                             );
                         })}
-
-                        {/* 現在のユーザーの手札を表示 */}
-                        <div style={{ marginTop: '20px' }}>
-                            <HandDisplay
-                                room={room}
-                                currentUser={currentUser}
-                                onSummonFollower={handleSummonFollower}
-                            />
-                        </div>
-
                         {/* バトルフィールド（ボード）を表示 */}
                         <div style={{ marginTop: '20px' }}>
                             <BoardDisplay
                                 room={room}
                                 currentUser={currentUser}
                                 refreshTrigger={boardRefreshTrigger}
+                            />
+                        </div>
+                        {/* 現在のユーザーの手札を表示 */}
+                        <div style={{ marginTop: '20px' }}>
+                            <HandDisplay
+                                room={room}
+                                currentUser={currentUser}
+                                onSummonFollower={handleSummonFollower}
                             />
                         </div>
                     </div>

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -131,17 +131,6 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
                                             )}
                                         </p>
                                     )}
-
-                                    {room.status === 'playing' && (
-                                        <p >
-                                            [DEBUG] デッキ: {selectedDeck ? selectedDeck.name : '未選択'}
-                                            {player.selectedDeckId && (
-                                                <span style={{ marginLeft: '5px' }}>
-                                                    (ID: {player.selectedDeckId})
-                                                </span>
-                                            )}
-                                        </p>
-                                    )}
                                 </div>
                             </div>
                         </div>
@@ -238,25 +227,6 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
 
                 {room.status === 'playing' && (
                     <div>
-                        <h4>
-                            [DEBUG] デッキ選択状況
-                        </h4>
-                        {roomPlayers.map((player, index) => {
-                            const user = getUserById(player.userId, mockUsers);
-                            const selectedDeck = player.selectedDeckId ? getDeckById(player.selectedDeckId) : null;
-                            return (
-                                <div key={player.id}>
-                                    <strong>{user?.name}</strong>: {' '}
-                                    {selectedDeck ? (
-                                        <span style={{ color: '#28a745' }}>
-                                            {selectedDeck.name} (ID: {player.selectedDeckId})
-                                        </span>
-                                    ) : (
-                                        <span style={{ color: '#dc3545' }}>デッキ未選択</span>
-                                    )}
-                                </div>
-                            );
-                        })}
                         {/* バトルフィールド（ボード）を表示 */}
                         <div style={{ marginTop: '20px' }}>
                             <BoardDisplay

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -9,6 +9,8 @@ import { currentUserAtom } from '@/lib/atoms';
 import { useState } from 'react';
 import { DeckSelector } from './DeckSelector';
 import { HandDisplay } from './HandDisplay';
+import { BoardDisplay } from './BoardDisplay';
+import { useGameActions } from '../_hooks/useGameActions';
 
 interface RoomDisplayProps {
     room: MockRoom;
@@ -21,6 +23,17 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
     const [currentUser] = useAtom(currentUserAtom);
     const [isStartingGame, setIsStartingGame] = useState(false);
     const [, forceUpdate] = useState({});
+    const [boardRefreshTrigger, setBoardRefreshTrigger] = useState(0);
+
+    // ゲームアクションフック
+    const { handleSummonFollower: originalHandleSummonFollower } = useGameActions();
+
+    // フォロワー召喚後にボードを更新
+    const handleSummonFollower = async (handCardId: string) => {
+        await originalHandleSummonFollower(handCardId);
+        setBoardRefreshTrigger(prev => prev + 1);
+        refreshData();
+    };
 
     const refreshData = () => {
         forceUpdate({});
@@ -247,7 +260,20 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
 
                         {/* 現在のユーザーの手札を表示 */}
                         <div style={{ marginTop: '20px' }}>
-                            <HandDisplay room={room} currentUser={currentUser} />
+                            <HandDisplay
+                                room={room}
+                                currentUser={currentUser}
+                                onSummonFollower={handleSummonFollower}
+                            />
+                        </div>
+
+                        {/* バトルフィールド（ボード）を表示 */}
+                        <div style={{ marginTop: '20px' }}>
+                            <BoardDisplay
+                                room={room}
+                                currentUser={currentUser}
+                                refreshTrigger={boardRefreshTrigger}
+                            />
                         </div>
                     </div>
                 )}

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -17,7 +17,6 @@ interface RoomDisplayProps {
 }
 
 export function RoomDisplay({ room }: RoomDisplayProps) {
-    // プレイヤー情報を取得
     const roomPlayers = getPlayersByRoomId(room.id);
     const router = useRouter();
     const [currentUser] = useAtom(currentUserAtom);
@@ -25,7 +24,6 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
     const [, forceUpdate] = useState({});
     const [boardRefreshTrigger, setBoardRefreshTrigger] = useState(0);
 
-    // ゲームアクションフック
     const { handleSummonFollower: originalHandleSummonFollower } = useGameActions();
 
     // フォロワー召喚後にボードを更新

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -24,11 +24,25 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
     const [, forceUpdate] = useState({});
     const [boardRefreshTrigger, setBoardRefreshTrigger] = useState(0);
 
-    const { handleSummonFollower: originalHandleSummonFollower } = useGameActions();
+    const {
+        handleSummonFollower: originalHandleSummonFollower,
+        handleAttackWithFollower: originalHandleAttackWithFollower
+    } = useGameActions();
 
     // フォロワー召喚後にボードを更新
     const handleSummonFollower = async (handCardId: string) => {
         await originalHandleSummonFollower(handCardId);
+        setBoardRefreshTrigger(prev => prev + 1);
+        refreshData();
+    };
+
+    // フォロワー攻撃後にボードを更新
+    const handleAttackWithFollower = async (
+        attackerBoardCardId: string,
+        targetType: 'follower' | 'player',
+        targetId: string
+    ) => {
+        await originalHandleAttackWithFollower(attackerBoardCardId, targetType, targetId);
         setBoardRefreshTrigger(prev => prev + 1);
         refreshData();
     };
@@ -231,6 +245,7 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
                                 room={room}
                                 currentUser={currentUser}
                                 refreshTrigger={boardRefreshTrigger}
+                                onAttackWithFollower={handleAttackWithFollower}
                             />
                         </div>
                         {/* 現在のユーザーの手札を表示 */}

--- a/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/_components/RoomDisplay.tsx
@@ -26,12 +26,20 @@ export function RoomDisplay({ room }: RoomDisplayProps) {
 
     const {
         handleSummonFollower: originalHandleSummonFollower,
-        handleAttackWithFollower: originalHandleAttackWithFollower
+        handleAttackWithFollower: originalHandleAttackWithFollower,
+        handleSummonFollowerToOpponent: originalHandleSummonFollowerToOpponent
     } = useGameActions();
 
     // フォロワー召喚後にボードを更新
     const handleSummonFollower = async (handCardId: string) => {
         await originalHandleSummonFollower(handCardId);
+        setBoardRefreshTrigger(prev => prev + 1);
+        refreshData();
+    };
+
+    // 相手フィールドにフォロワー召喚後にボードを更新
+    const handleSummonFollowerToOpponent = async (targetUserId: string, followerId: string) => {
+        await originalHandleSummonFollowerToOpponent(targetUserId, followerId);
         setBoardRefreshTrigger(prev => prev + 1);
         refreshData();
     };

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
@@ -118,6 +118,27 @@ export function useGameActions() {
         }
     };
 
+    const handleSummonFollowerToOpponent = async (targetUserId: string, followerId: string) => {
+        try {
+            setLoading(true);
+            setError(null);
+            const errorMessage = await gameActions.handleSummonFollowerToOpponent(
+                currentUser,
+                targetUserId,
+                followerId
+            );
+
+            if (errorMessage) {
+                setError(errorMessage);
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : '相手フィールドへの召喚に失敗しました';
+            setError(errorMessage);
+        } finally {
+            setLoading(false);
+        }
+    };
+
     return {
         handleStartTurn,
         handleEndTurn,
@@ -128,5 +149,6 @@ export function useGameActions() {
         handleDamageToOpponent,
         handleSummonFollower,
         handleAttackWithFollower,
+        handleSummonFollowerToOpponent,
     };
 }

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
@@ -75,9 +75,21 @@ export function useGameActions() {
     };
 
     const handleSummonFollower = async (handCardId: string) => {
-        await handleWithLoading(async () => {
-            await gameActions.handleSummonFollower(currentUser, handCardId);
-        });
+        try {
+            setLoading(true);
+            setError(null);
+            const errorMessage = await gameActions.handleSummonFollower(currentUser, handCardId);
+
+            if (errorMessage) {
+                // エラーメッセージがある場合はエラーとして設定
+                setError(errorMessage);
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : '召喚に失敗しました';
+            setError(errorMessage);
+        } finally {
+            setLoading(false);
+        }
     };
 
     return {

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
@@ -74,6 +74,12 @@ export function useGameActions() {
         });
     };
 
+    const handleSummonFollower = async (handCardId: string) => {
+        await handleWithLoading(async () => {
+            await gameActions.handleSummonFollower(currentUser, handCardId);
+        });
+    };
+
     return {
         handleStartTurn,
         handleEndTurn,
@@ -82,5 +88,6 @@ export function useGameActions() {
         handleDamagePlayer,
         handleDamageToSelf,
         handleDamageToOpponent,
+        handleSummonFollower,
     };
 }

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActions.ts
@@ -92,6 +92,32 @@ export function useGameActions() {
         }
     };
 
+    const handleAttackWithFollower = async (
+        attackerBoardCardId: string,
+        targetType: 'follower' | 'player',
+        targetId: string
+    ) => {
+        try {
+            setLoading(true);
+            setError(null);
+            const errorMessage = await gameActions.handleAttackWithFollower(
+                currentUser,
+                attackerBoardCardId,
+                targetType,
+                targetId
+            );
+
+            if (errorMessage) {
+                setError(errorMessage);
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : '攻撃に失敗しました';
+            setError(errorMessage);
+        } finally {
+            setLoading(false);
+        }
+    };
+
     return {
         handleStartTurn,
         handleEndTurn,
@@ -101,5 +127,6 @@ export function useGameActions() {
         handleDamageToSelf,
         handleDamageToOpponent,
         handleSummonFollower,
+        handleAttackWithFollower,
     };
 }

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
@@ -96,18 +96,24 @@ export function useGameActionsCore(roomId: string | null) {
     };
 
     // フォロワーを召喚
-    const handleSummonFollower = async (currentUser: MockUser, handCardId: string): Promise<void> => {
-        if (!roomId) return;
+    const handleSummonFollower = async (currentUser: MockUser, handCardId: string): Promise<string | null> => {
+        if (!roomId) return '部屋が見つかりません';
 
         try {
-            await mockApi.summonFollower({
+            const result = await mockApi.summonFollower({
                 roomId,
                 currentUser,
                 handCardId
             });
-            await updateRoomCache(roomId);
+
+            if (result.success) {
+                await updateRoomCache(roomId);
+                return null; // 成功の場合はnullを返す
+            } else {
+                return result.message || '召喚に失敗しました'; // エラーメッセージを返す
+            }
         } catch (error) {
-            throw error;
+            return error instanceof Error ? error.message : '召喚に失敗しました';
         }
     };
 

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
@@ -146,6 +146,33 @@ export function useGameActionsCore(roomId: string | null) {
         }
     };
 
+    // 相手フィールドにフォロワーを召喚（デモ機能）
+    const handleSummonFollowerToOpponent = async (
+        currentUser: MockUser,
+        targetUserId: string,
+        followerId: string
+    ): Promise<string | null> => {
+        if (!roomId) return '部屋が見つかりません';
+
+        try {
+            const result = await mockApi.summonFollowerToOpponent({
+                roomId,
+                currentUser,
+                targetUserId,
+                followerId
+            });
+
+            if (result.success) {
+                await updateRoomCache(roomId);
+                return null;
+            } else {
+                return result.message || '相手フィールドへの召喚に失敗しました';
+            }
+        } catch (error) {
+            return error instanceof Error ? error.message : '相手フィールドへの召喚に失敗しました';
+        }
+    };
+
     return {
         handleStartTurn,
         handleEndTurn,
@@ -156,5 +183,6 @@ export function useGameActionsCore(roomId: string | null) {
         handleDamageToOpponent,
         handleSummonFollower,
         handleAttackWithFollower,
+        handleSummonFollowerToOpponent,
     };
 }

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
@@ -117,6 +117,35 @@ export function useGameActionsCore(roomId: string | null) {
         }
     };
 
+    // フォロワーで攻撃
+    const handleAttackWithFollower = async (
+        currentUser: MockUser,
+        attackerBoardCardId: string,
+        targetType: 'follower' | 'player',
+        targetId: string
+    ): Promise<string | null> => {
+        if (!roomId) return '部屋が見つかりません';
+
+        try {
+            const result = await mockApi.attackWithFollower({
+                roomId,
+                currentUser,
+                attackerBoardCardId,
+                targetType,
+                targetId
+            });
+
+            if (result.success) {
+                await updateRoomCache(roomId);
+                return null;
+            } else {
+                return result.message || '攻撃に失敗しました';
+            }
+        } catch (error) {
+            return error instanceof Error ? error.message : '攻撃に失敗しました';
+        }
+    };
+
     return {
         handleStartTurn,
         handleEndTurn,
@@ -126,5 +155,6 @@ export function useGameActionsCore(roomId: string | null) {
         handleDamageToSelf,
         handleDamageToOpponent,
         handleSummonFollower,
+        handleAttackWithFollower,
     };
 }

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useGameActionsCore.ts
@@ -95,6 +95,22 @@ export function useGameActionsCore(roomId: string | null) {
         await handleDamagePlayer(currentUser, opponentUserId, damage);
     };
 
+    // フォロワーを召喚
+    const handleSummonFollower = async (currentUser: MockUser, handCardId: string): Promise<void> => {
+        if (!roomId) return;
+
+        try {
+            await mockApi.summonFollower({
+                roomId,
+                currentUser,
+                handCardId
+            });
+            await updateRoomCache(roomId);
+        } catch (error) {
+            throw error;
+        }
+    };
+
     return {
         handleStartTurn,
         handleEndTurn,
@@ -103,5 +119,6 @@ export function useGameActionsCore(roomId: string | null) {
         handleDamagePlayer,
         handleDamageToSelf,
         handleDamageToOpponent,
+        handleSummonFollower,
     };
 }

--- a/frontend/src/app/room/[roomId]/[status]/_hooks/useRoom.ts
+++ b/frontend/src/app/room/[roomId]/[status]/_hooks/useRoom.ts
@@ -2,7 +2,7 @@ import useSWR from 'swr';
 import { mockApi } from '@/lib/mockApi';
 import type { MockRoom } from '@/lib/types';
 
-//特定の部屋の情報を取得するSWR
+//特定の部屋の情報を取得する
 export function useRoom(roomId: string | null) {
     const { data, error, isLoading, mutate } = useSWR<MockRoom | null, Error>(
         roomId ? `/api/rooms/${roomId}` : null,

--- a/frontend/src/app/room/[roomId]/[status]/page.tsx
+++ b/frontend/src/app/room/[roomId]/[status]/page.tsx
@@ -64,6 +64,7 @@ export default function RoomStatusPage() {
                             onDamagePlayer={gameActions.handleDamagePlayer}
                             onDamageToSelf={gameActions.handleDamageToSelf}
                             onDamageToOpponent={gameActions.handleDamageToOpponent}
+                            onSummonFollowerToOpponent={gameActions.handleSummonFollowerToOpponent}
                         />
                     )}
                 </div>

--- a/frontend/src/lib/gameLogic.ts
+++ b/frontend/src/lib/gameLogic.ts
@@ -1,6 +1,6 @@
 import { GAME_CONSTANTS } from './constants';
 import type { MockRoom, MockRoomPlayer, MockUser, MockBoardCard } from './types';
-import { getPlayersByRoomId, getBoardByRoomPlayerId } from './mockData';
+import { getPlayersByRoomId, getBoardByRoomPlayerId, attackedFollowersThisTurn } from './mockData';
 
 // ユーザー情報取得
 export const getUserById = (userId: string, mockUsers: MockUser[]): MockUser | undefined => {
@@ -87,8 +87,31 @@ export const switchTurns = (room: MockRoom, currentActivePlayer: MockRoomPlayer)
 
 // ターン開始時にフォロワーの攻撃状態をリセット
 export const resetFollowerAttackStatus = (roomPlayerId: string): void => {
-    const playerBoard = getBoardByRoomPlayerId(roomPlayerId);
-    playerBoard.forEach((card: MockBoardCard) => {
-        card.hasAttackedThisTurn = false;
-    });
+    // 攻撃済みフォロワーのリストをクリア
+    attackedFollowersThisTurn.clear();
+};
+
+// フォロワーが攻撃可能かどうかを判定
+export const canFollowerAttack = (boardCard: MockBoardCard, currentTurn: number): boolean => {
+    // 召喚酔い
+    if (boardCard.summonedTurn === currentTurn) {
+        return false;
+    }
+
+    // 攻撃済み
+    if (attackedFollowersThisTurn.has(boardCard.id)) {
+        return false;
+    }
+
+    return true;
+};
+
+// フォロワーを攻撃済みにマーク
+export const markFollowerAsAttacked = (boardCardId: string): void => {
+    attackedFollowersThisTurn.add(boardCardId);
+};
+
+// フォロワーが攻撃済みかどうかを判定
+export const hasFollowerAttackedThisTurn = (boardCardId: string): boolean => {
+    return attackedFollowersThisTurn.has(boardCardId);
 };

--- a/frontend/src/lib/gameLogic.ts
+++ b/frontend/src/lib/gameLogic.ts
@@ -1,6 +1,6 @@
 import { GAME_CONSTANTS } from './constants';
-import type { MockRoom, MockRoomPlayer, MockUser } from './types';
-import { getPlayersByRoomId } from './mockData';
+import type { MockRoom, MockRoomPlayer, MockUser, MockBoardCard } from './types';
+import { getPlayersByRoomId, getBoardByRoomPlayerId } from './mockData';
 
 // ユーザー情報取得
 export const getUserById = (userId: string, mockUsers: MockUser[]): MockUser | undefined => {
@@ -83,4 +83,12 @@ export const switchTurns = (room: MockRoom, currentActivePlayer: MockRoomPlayer)
         player2.turnStatus = 'ended';
         recoverPlayerPP(player1);
     }
+};
+
+// ターン開始時にフォロワーの攻撃権をリセット
+export const resetFollowerAttackStatus = (roomPlayerId: string): void => {
+    const playerBoard = getBoardByRoomPlayerId(roomPlayerId);
+    playerBoard.forEach((card: MockBoardCard) => {
+        card.canAttack = true;
+    });
 };

--- a/frontend/src/lib/gameLogic.ts
+++ b/frontend/src/lib/gameLogic.ts
@@ -85,10 +85,10 @@ export const switchTurns = (room: MockRoom, currentActivePlayer: MockRoomPlayer)
     }
 };
 
-// ターン開始時にフォロワーの攻撃権をリセット
+// ターン開始時にフォロワーの攻撃状態をリセット
 export const resetFollowerAttackStatus = (roomPlayerId: string): void => {
     const playerBoard = getBoardByRoomPlayerId(roomPlayerId);
     playerBoard.forEach((card: MockBoardCard) => {
-        card.canAttack = true;
+        card.hasAttackedThisTurn = false;
     });
 };

--- a/frontend/src/lib/mockApi.ts
+++ b/frontend/src/lib/mockApi.ts
@@ -14,11 +14,8 @@ import {
     getDeckById,
     getDeckCardsByDeckId,
     getHandsByRoomPlayerId,
-    updateMockRoomPlayers,
-    updateMockHands,
     getFollowerById,
     getBoardByRoomPlayerId,
-    updateMockBoard,
     mockBoard
 } from './mockData';
 import type {
@@ -344,7 +341,6 @@ export const mockApi = {
             }
         } catch (error) {
             console.error(`Failed to draw card at turn start for player ${input.currentUser.name}:`, error);
-            // ドローに失敗してもターン開始は継続
         }
 
         return player;
@@ -411,7 +407,7 @@ export const mockApi = {
         return room;
     },
 
-    // PP消費（デモ用）
+    // PP消費
     consumePP: async (input: ConsumePPInput): Promise<MockRoomPlayer | null> => {
         const room = getRoomById(input.roomId);
         if (!room) return null;

--- a/frontend/src/lib/mockApi.ts
+++ b/frontend/src/lib/mockApi.ts
@@ -586,6 +586,12 @@ export const mockApi = {
         return hands;
     },
 
+    // プレイヤーのボードを取得
+    getBoard: async (input: { roomPlayerId: string }): Promise<MockBoardCard[]> => {
+        const boards = getBoardByRoomPlayerId(input.roomPlayerId);
+        return boards;
+    },
+
     // フォロワーを召喚
     summonFollower: async (input: SummonFollowerInput): Promise<MockBoardCard> => {
         const room = getRoomById(input.roomId);

--- a/frontend/src/lib/mockApi.ts
+++ b/frontend/src/lib/mockApi.ts
@@ -310,7 +310,7 @@ export const mockApi = {
         player.turn = playerTurn;
         recoverPlayerPP(player);
 
-        // ターン開始時にフォロワーの攻撃権をリセット
+        // ターン開始時にフォロワーの攻撃状態をリセット
         resetFollowerAttackStatus(player.id);
 
         // ターン開始時に1枚ドロー
@@ -381,7 +381,7 @@ export const mockApi = {
                     nextPlayer.turn = nextPlayerTurn;
                     recoverPlayerPP(nextPlayer);
 
-                    // ターン開始時にフォロワーの攻撃権をリセット
+                    // ターン開始時にフォロワーの攻撃状態をリセット
                     resetFollowerAttackStatus(nextPlayer.id);
 
                     // ターン開始時に1枚ドロー
@@ -479,7 +479,7 @@ export const mockApi = {
                     nextPlayer.turn = nextPlayerTurn;
                     recoverPlayerPP(nextPlayer);
 
-                    // ターン開始時にフォロワーの攻撃権をリセット
+                    // ターン開始時にフォロワーの攻撃状態をリセット
                     resetFollowerAttackStatus(nextPlayer.id);
 
                     // ターン開始時に1枚ドロー
@@ -671,7 +671,8 @@ export const mockApi = {
             attack: handCard.attack,
             hp: handCard.hp,
             position: currentBoardCards.length,
-            canAttack: false
+            summonedTurn: player.turn,
+            hasAttackedThisTurn: false
         };
 
         mockBoard.push(boardCard);
@@ -731,11 +732,19 @@ export const mockApi = {
             };
         }
 
-        // 攻撃可能かチェック
-        if (!attackerCard.canAttack) {
+        // 攻撃可能かチェック（召喚酔い・攻撃済みチェック）
+        if (attackerCard.summonedTurn === player.turn) {
             return {
                 success: false,
-                message: 'このフォロワーは攻撃できません',
+                message: 'このフォロワーは召喚酔いで攻撃できません',
+                reason: 'cannot_attack'
+            };
+        }
+
+        if (attackerCard.hasAttackedThisTurn) {
+            return {
+                success: false,
+                message: 'このフォロワーは既に攻撃済みです',
                 reason: 'cannot_attack'
             };
         }
@@ -758,7 +767,7 @@ export const mockApi = {
             targetPlayer.hp = newHp;
 
             // 攻撃者は攻撃済みにする
-            attackerCard.canAttack = false;
+            attackerCard.hasAttackedThisTurn = true;
 
             // 勝敗判定
             if (newHp <= 0) {
@@ -800,7 +809,7 @@ export const mockApi = {
             targetCard.hp -= attackerDamage;
 
             // 攻撃者は攻撃済みにする
-            attackerCard.canAttack = false;
+            attackerCard.hasAttackedThisTurn = true;
 
             // 破壊チェック
             if (attackerCard.hp <= 0) {

--- a/frontend/src/lib/mockApi.ts
+++ b/frontend/src/lib/mockApi.ts
@@ -44,7 +44,9 @@ import type {
     SummonFollowerInput,
     SummonFollowerResult,
     AttackInput,
-    AttackResult
+    AttackResult,
+    SummonFollowerToOpponentInput,
+    SummonFollowerToOpponentResult
 } from './types';
 
 export const mockApi = {
@@ -839,6 +841,69 @@ export const mockApi = {
             success: false,
             message: '無効な攻撃対象です',
             reason: 'invalid_target'
+        };
+    },
+
+    // 相手フィールドにフォロワーを召喚（デモ機能）
+    summonFollowerToOpponent: async (input: SummonFollowerToOpponentInput): Promise<SummonFollowerToOpponentResult> => {
+        const room = getRoomById(input.roomId);
+        if (!room) {
+            return {
+                success: false,
+                message: 'ルームが見つかりません',
+                reason: 'unknown'
+            };
+        }
+
+        // 対象プレイヤーを取得
+        const targetPlayer = getPlayerByUserIdAndRoomId(input.targetUserId, input.roomId);
+        if (!targetPlayer) {
+            return {
+                success: false,
+                message: '対象プレイヤーが見つかりません',
+                reason: 'target_not_found'
+            };
+        }
+
+        // フォロワー情報を取得
+        const follower = getFollowerById(input.followerId);
+        if (!follower) {
+            return {
+                success: false,
+                message: '指定されたフォロワーが見つかりません',
+                reason: 'follower_not_found'
+            };
+        }
+
+        // ボードの空きスペースをチェック
+        const currentBoardCards = getBoardByRoomPlayerId(targetPlayer.id);
+        if (currentBoardCards.length >= 5) {
+            return {
+                success: false,
+                message: 'ボードが満員です（最大5体まで）',
+                reason: 'board_full'
+            };
+        }
+
+        // ボードにカードを追加
+        const boardCard: MockBoardCard = {
+            id: `board_${targetPlayer.id}_${Date.now()}_demo`,
+            roomPlayerId: targetPlayer.id,
+            cardId: follower.id,
+            cost: follower.cost,
+            attack: follower.attack,
+            hp: follower.hp,
+            position: currentBoardCards.length,
+            summonedTurn: targetPlayer.turn,
+            hasAttackedThisTurn: false
+        };
+
+        mockBoard.push(boardCard);
+
+        return {
+            success: true,
+            boardCard: boardCard,
+            message: `相手フィールドに${follower.name}を召喚しました`
         };
     },
 };

--- a/frontend/src/lib/mockApi.ts
+++ b/frontend/src/lib/mockApi.ts
@@ -1,5 +1,5 @@
 import { GAME_CONSTANTS } from './constants';
-import { calculatePPMax, calculatePlayerTurn, getActivePlayer, recoverPlayerPP, switchTurns } from './gameLogic';
+import { calculatePPMax, calculatePlayerTurn, getActivePlayer, recoverPlayerPP, switchTurns, resetFollowerAttackStatus } from './gameLogic';
 import {
     mockUsers,
     mockRooms,
@@ -42,7 +42,9 @@ import type {
     DrawCardsInput,
     GetHandInput,
     SummonFollowerInput,
-    SummonFollowerResult
+    SummonFollowerResult,
+    AttackInput,
+    AttackResult
 } from './types';
 
 export const mockApi = {
@@ -308,6 +310,9 @@ export const mockApi = {
         player.turn = playerTurn;
         recoverPlayerPP(player);
 
+        // ターン開始時にフォロワーの攻撃権をリセット
+        resetFollowerAttackStatus(player.id);
+
         // ターン開始時に1枚ドロー
         try {
             if (!player.selectedDeckId) {
@@ -375,6 +380,9 @@ export const mockApi = {
                     const nextPlayerTurn = calculatePlayerTurn(room, nextPlayerIndex);
                     nextPlayer.turn = nextPlayerTurn;
                     recoverPlayerPP(nextPlayer);
+
+                    // ターン開始時にフォロワーの攻撃権をリセット
+                    resetFollowerAttackStatus(nextPlayer.id);
 
                     // ターン開始時に1枚ドロー
                     if (nextPlayer.selectedDeckId) {
@@ -470,6 +478,9 @@ export const mockApi = {
                     const nextPlayerTurn = calculatePlayerTurn(room, nextPlayerIndex);
                     nextPlayer.turn = nextPlayerTurn;
                     recoverPlayerPP(nextPlayer);
+
+                    // ターン開始時にフォロワーの攻撃権をリセット
+                    resetFollowerAttackStatus(nextPlayer.id);
 
                     // ターン開始時に1枚ドロー
                     if (nextPlayer.selectedDeckId) {
@@ -659,7 +670,8 @@ export const mockApi = {
             cost: handCard.cost,
             attack: handCard.attack,
             hp: handCard.hp,
-            position: currentBoardCards.length
+            position: currentBoardCards.length,
+            canAttack: false
         };
 
         mockBoard.push(boardCard);
@@ -674,6 +686,150 @@ export const mockApi = {
             success: true,
             boardCard: boardCard,
             message: 'フォロワーを召喚しました'
+        };
+    },
+
+    // フォロワーで攻撃
+    attackWithFollower: async (input: AttackInput): Promise<AttackResult> => {
+        const room = getRoomById(input.roomId);
+        if (!room) {
+            return {
+                success: false,
+                message: 'ルームが見つかりません',
+                reason: 'unknown'
+            };
+        }
+
+        const player = getPlayerByUserIdAndRoomId(input.currentUser.id, input.roomId);
+        if (!player) {
+            return {
+                success: false,
+                message: 'プレイヤーが見つかりません',
+                reason: 'unknown'
+            };
+        }
+
+        // アクティブプレイヤーかチェック
+        const activePlayer = getActivePlayer(room);
+        if (!activePlayer || activePlayer.userId !== input.currentUser.id) {
+            return {
+                success: false,
+                message: 'あなたのターンではありません',
+                reason: 'not_your_turn'
+            };
+        }
+
+        // 攻撃者のフォロワーを取得
+        const attackerCard = mockBoard.find(card =>
+            card.id === input.attackerBoardCardId && card.roomPlayerId === player.id
+        );
+        if (!attackerCard) {
+            return {
+                success: false,
+                message: '攻撃者フォロワーが見つかりません',
+                reason: 'attacker_not_found'
+            };
+        }
+
+        // 攻撃可能かチェック
+        if (!attackerCard.canAttack) {
+            return {
+                success: false,
+                message: 'このフォロワーは攻撃できません',
+                reason: 'cannot_attack'
+            };
+        }
+
+        const destroyedFollowers: string[] = [];
+
+        if (input.targetType === 'player') {
+            // プレイヤーへの攻撃
+            const targetPlayer = getPlayerByUserIdAndRoomId(input.targetId, input.roomId);
+            if (!targetPlayer) {
+                return {
+                    success: false,
+                    message: '攻撃対象プレイヤーが見つかりません',
+                    reason: 'target_not_found'
+                };
+            }
+
+            // ダメージを与える
+            const newHp = Math.max(0, targetPlayer.hp - attackerCard.attack);
+            targetPlayer.hp = newHp;
+
+            // 攻撃者は攻撃済みにする
+            attackerCard.canAttack = false;
+
+            // 勝敗判定
+            if (newHp <= 0) {
+                room.status = 'finish';
+            }
+
+            return {
+                success: true,
+                message: `プレイヤーに${attackerCard.attack}ダメージを与えました`,
+                destroyedFollowers
+            };
+
+        } else if (input.targetType === 'follower') {
+            // フォロワーへの攻撃
+            const targetCard = mockBoard.find(card => card.id === input.targetId);
+            if (!targetCard) {
+                return {
+                    success: false,
+                    message: '攻撃対象フォロワーが見つかりません',
+                    reason: 'target_not_found'
+                };
+            }
+
+            // 相手のフォロワーかチェック
+            if (targetCard.roomPlayerId === player.id) {
+                return {
+                    success: false,
+                    message: '自分のフォロワーは攻撃できません',
+                    reason: 'invalid_target'
+                };
+            }
+
+            // 戦闘ダメージ計算
+            const attackerDamage = attackerCard.attack;
+            const defenderDamage = targetCard.attack;
+
+            // 相互ダメージ
+            attackerCard.hp -= defenderDamage;
+            targetCard.hp -= attackerDamage;
+
+            // 攻撃者は攻撃済みにする
+            attackerCard.canAttack = false;
+
+            // 破壊チェック
+            if (attackerCard.hp <= 0) {
+                const attackerIndex = mockBoard.findIndex(card => card.id === attackerCard.id);
+                if (attackerIndex !== -1) {
+                    mockBoard.splice(attackerIndex, 1);
+                    destroyedFollowers.push(attackerCard.id);
+                }
+            }
+
+            if (targetCard.hp <= 0) {
+                const targetIndex = mockBoard.findIndex(card => card.id === targetCard.id);
+                if (targetIndex !== -1) {
+                    mockBoard.splice(targetIndex, 1);
+                    destroyedFollowers.push(targetCard.id);
+                }
+            }
+
+            return {
+                success: true,
+                message: `フォロワー同士の戦闘が発生しました`,
+                destroyedFollowers
+            };
+        }
+
+        return {
+            success: false,
+            message: '無効な攻撃対象です',
+            reason: 'invalid_target'
         };
     },
 };

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -1,5 +1,5 @@
 import { GAME_CONSTANTS } from './constants';
-import type { MockUser, MockRoom, MockRoomPlayer, MockDeck, MockDeckCard, MockHand, MockFollower } from './types';
+import type { MockUser, MockRoom, MockRoomPlayer, MockDeck, MockDeckCard, MockHand, MockFollower, MockBoardCard } from './types';
 
 // ユーザー
 export const mockUsers: MockUser[] = [
@@ -140,7 +140,12 @@ export let mockDeckCards: MockDeckCard[] = [
 
 // 手札（プレイヤーが現在持っているカード）
 export let mockHands: MockHand[] = [
-    // 現在は空 - ドロー処理で追加される
+
+];
+
+// ボード（場に出ているフォロワー）
+export let mockBoard: MockBoardCard[] = [
+
 ];
 
 // フォロワー（カードの基本情報）
@@ -200,6 +205,16 @@ export const getHandsByRoomPlayerId = (roomPlayerId: string): MockHand[] => {
 // 手札を更新する関数
 export const updateMockHands = (newHands: MockHand[]) => {
     mockHands = newHands;
+};
+
+// プレイヤーのボードを取得する関数
+export const getBoardByRoomPlayerId = (roomPlayerId: string): MockBoardCard[] => {
+    return mockBoard.filter(board => board.roomPlayerId === roomPlayerId);
+};
+
+// ボードを更新する関数
+export const updateMockBoard = (newBoard: MockBoardCard[]) => {
+    mockBoard = newBoard;
 };
 
 // フォロワーIDでフォロワー情報を取得する関数

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -162,11 +162,6 @@ export const mockFollowers: MockFollower[] = [
     { id: 'card10', name: 'エンシェントドラゴン', cost: 6, attack: 4, hp: 7 },
 ];
 
-// プレイヤーデータを更新する関数
-export const updateMockRoomPlayers = (newPlayers: MockRoomPlayer[]) => {
-    mockRoomPlayers = newPlayers;
-};
-
 // モックデータから部屋を検索する関数
 export const getRoomById = (roomId: string): MockRoom | undefined => {
     return mockRooms.find(r => r.id === roomId);
@@ -202,19 +197,9 @@ export const getHandsByRoomPlayerId = (roomPlayerId: string): MockHand[] => {
     return mockHands.filter(hand => hand.roomPlayerId === roomPlayerId);
 };
 
-// 手札を更新する関数
-export const updateMockHands = (newHands: MockHand[]) => {
-    mockHands = newHands;
-};
-
 // プレイヤーのボードを取得する関数
 export const getBoardByRoomPlayerId = (roomPlayerId: string): MockBoardCard[] => {
     return mockBoard.filter(board => board.roomPlayerId === roomPlayerId);
-};
-
-// ボードを更新する関数
-export const updateMockBoard = (newBoard: MockBoardCard[]) => {
-    mockBoard = newBoard;
 };
 
 // フォロワーIDでフォロワー情報を取得する関数

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -148,6 +148,9 @@ export let mockBoard: MockBoardCard[] = [
 
 ];
 
+// 攻撃済みフォロワーのリスト（ターンごとにリセット）
+export let attackedFollowersThisTurn: Set<string> = new Set();
+
 // フォロワー（カードの基本情報）
 export const mockFollowers: MockFollower[] = [
     { id: 'card1', name: 'ゴブリン', cost: 1, attack: 2, hp: 1 },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -40,7 +40,8 @@ export interface MockBoardCard {
     cost: number;
     attack: number;
     hp: number;
-    position: number; // ボード上の位置 (0-6)
+    position: number;
+    canAttack: boolean;
 }
 
 export interface MockRoomPlayer {
@@ -150,4 +151,19 @@ export interface SummonFollowerResult {
     boardCard?: MockBoardCard;
     message?: string;
     reason?: 'board_full' | 'insufficient_pp' | 'invalid_card' | 'not_your_turn' | 'unknown';
+}
+
+export interface AttackInput {
+    roomId: string;
+    currentUser: MockUser;
+    attackerBoardCardId: string;
+    targetType: 'follower' | 'player';
+    targetId: string;
+}
+
+export interface AttackResult {
+    success: boolean;
+    message?: string;
+    reason?: 'not_your_turn' | 'cannot_attack' | 'invalid_target' | 'attacker_not_found' | 'target_not_found' | 'unknown';
+    destroyedFollowers?: string[];
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -41,7 +41,8 @@ export interface MockBoardCard {
     attack: number;
     hp: number;
     position: number;
-    canAttack: boolean;
+    summonedTurn: number; // 召喚されたターン数
+    hasAttackedThisTurn: boolean; // このターンに攻撃済みか
 }
 
 export interface MockRoomPlayer {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -42,7 +42,6 @@ export interface MockBoardCard {
     hp: number;
     position: number;
     summonedTurn: number;
-    hasAttackedThisTurn: boolean;
 }
 
 export interface MockRoomPlayer {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -144,3 +144,10 @@ export interface SummonFollowerInput {
     currentUser: MockUser;
     handCardId: string;
 }
+
+export interface SummonFollowerResult {
+    success: boolean;
+    boardCard?: MockBoardCard;
+    message?: string;
+    reason?: 'board_full' | 'insufficient_pp' | 'invalid_card' | 'not_your_turn' | 'unknown';
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -41,8 +41,8 @@ export interface MockBoardCard {
     attack: number;
     hp: number;
     position: number;
-    summonedTurn: number; // 召喚されたターン数
-    hasAttackedThisTurn: boolean; // このターンに攻撃済みか
+    summonedTurn: number;
+    hasAttackedThisTurn: boolean;
 }
 
 export interface MockRoomPlayer {
@@ -152,6 +152,20 @@ export interface SummonFollowerResult {
     boardCard?: MockBoardCard;
     message?: string;
     reason?: 'board_full' | 'insufficient_pp' | 'invalid_card' | 'not_your_turn' | 'unknown';
+}
+//demo(後で消してよし)
+export interface SummonFollowerToOpponentInput {
+    roomId: string;
+    currentUser: MockUser;
+    targetUserId: string;
+    followerId: string;
+}
+//demo(後で消してよし)
+export interface SummonFollowerToOpponentResult {
+    success: boolean;
+    boardCard?: MockBoardCard;
+    message?: string;
+    reason?: 'board_full' | 'target_not_found' | 'follower_not_found' | 'unknown';
 }
 
 export interface AttackInput {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -33,6 +33,16 @@ export interface MockHand {
     hp: number;
 }
 
+export interface MockBoardCard {
+    id: string;
+    roomPlayerId: string;
+    cardId: string;
+    cost: number;
+    attack: number;
+    hp: number;
+    position: number; // ボード上の位置 (0-6)
+}
+
 export interface MockRoomPlayer {
     id: string;
     roomId: string;
@@ -127,4 +137,10 @@ export interface DrawCardsInput {
 export interface GetHandInput {
     roomId: string;
     currentUser: MockUser;
+}
+
+export interface SummonFollowerInput {
+    roomId: string;
+    currentUser: MockUser;
+    handCardId: string;
 }


### PR DESCRIPTION
## 先にやること
https://github.com/2507-aws-himawari/menkoverse/pull/61

上記のPRがマージの後マージ

## 該当Issue
https://github.com/2507-aws-himawari/menkoverse/issues/48
https://github.com/2507-aws-himawari/menkoverse/issues/41
https://github.com/2507-aws-himawari/menkoverse/issues/63

## 概要
- 召喚ターンは攻撃できない
- １ターンに１攻撃
- プレイヤーに攻撃
- フォロワーに攻撃

## データのカラム追加
いつ召喚されたか判断
```
summonedTurn: number;
```

## demo

https://github.com/user-attachments/assets/fadc1834-6e93-4148-8c1d-a3e96c8a5992



