### PR TITLE
App Runner に OpenCV API サーバーをぶんなげた

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -246,5 +246,12 @@ export class AppStack extends cdk.Stack {
       exportName: `${this.stackName}-AppRunnerServiceId`,
       value: this.appRunnerService.attrServiceId,
     });
+
+    new cdk.CfnOutput(this, 'CfnOutputVpcConnectorArn', {
+      key: 'VpcConnectorArn',
+      description: 'VPC Connector ARN for App Runner services',
+      exportName: `${this.stackName}-VpcConnectorArn`,
+      value: vpcConnector.attrVpcConnectorArn,
+    });
   }
 }

--- a/cdk/lib/opencv-stack.ts
+++ b/cdk/lib/opencv-stack.ts
@@ -1,0 +1,139 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as apprunner from 'aws-cdk-lib/aws-apprunner';
+import * as logs from 'aws-cdk-lib/aws-logs';
+
+export interface OpenCVStackProps extends cdk.StackProps {
+  /**
+   * VPC Connector ARN from App Stack
+   */
+  readonly vpcConnectorArn: string;
+  /**
+   * GitHub repository URL for App Runner
+   * @default 'https://github.com/2507-aws-himawari/menkoverse'
+   */
+  readonly repositoryUrl?: string;
+  /**
+   * GitHub branch for App Runner
+   * @default 'main'
+   */
+  readonly branch?: string;
+  /**
+   * Connection ARN for App Runner
+   */
+  readonly connectionArn?: string;
+  /**
+   * Environment name for resource naming
+   * @default 'dev'
+   */
+  readonly environment?: string;
+  /**
+   * Frontend App Runner Service URL for CORS
+   */
+  readonly frontendUrl?: string;
+}
+
+export class OpenCVStack extends cdk.Stack {
+  /**
+   * OpenCV App Runner Service
+   */
+  public readonly appRunnerService: apprunner.CfnService;
+
+  public constructor(scope: cdk.App, id: string, props: OpenCVStackProps) {
+    super(scope, id, props);
+
+    const envName = props.environment ?? 'dev';
+    const repositoryUrl = props.repositoryUrl ?? 'https://github.com/2507-aws-himawari/menkoverse';
+    const branch = props.branch ?? 'main';
+    const connectionArn = props.connectionArn ?? "arn:aws:apprunner:ap-northeast-1:073825268718:connection/himawari/9372ad1b3cba4a7d84c6798e4450df0f";
+
+    // App Runner Instance Role
+    const appRunnerInstanceRole = new iam.Role(this, 'OpenCVAppRunnerInstanceRole', {
+      assumedBy: new iam.ServicePrincipal('tasks.apprunner.amazonaws.com'),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSAppRunnerServicePolicyForECRAccess'),
+      ],
+    });
+
+    // App Runner Service
+    this.appRunnerService = new apprunner.CfnService(this, 'OpenCVAppRunnerService', {
+      serviceName: `opencv-api-${envName}`,
+      sourceConfiguration: {
+        authenticationConfiguration: {
+          connectionArn: connectionArn,
+        },
+        autoDeploymentsEnabled: true,
+        codeRepository: {
+          repositoryUrl: repositoryUrl,
+          sourceCodeVersion: {
+            type: 'BRANCH',
+            value: branch,
+          },
+          sourceDirectory: 'opencv',
+          codeConfiguration: {
+            configurationSource: 'API',
+            codeConfigurationValues: {
+              runtime: 'PYTHON_3',
+              buildCommand: 'pip install --no-cache-dir -r requirements.txt',
+              startCommand: 'python -m uvicorn main:app --host 0.0.0.0 --port 5000',
+              port: '5000',
+              runtimeEnvironmentVariables: [
+                {
+                  name: 'ENVIRONMENT',
+                  value: envName,
+                },
+                {
+                  name: 'FRONTEND_URL',
+                  value: props.frontendUrl ?? 'http://localhost:3000',
+                },
+                {
+                  name: 'PYTHONUNBUFFERED',
+                  value: '1',
+                },
+              ],
+            },
+          },
+        },
+      },
+      networkConfiguration: {
+        egressConfiguration: {
+          egressType: 'VPC',
+          vpcConnectorArn: props.vpcConnectorArn,
+        },
+      },
+      instanceConfiguration: {
+        instanceRoleArn: appRunnerInstanceRole.roleArn,
+        cpu: envName === 'prod' ? '1024' : '512',
+        memory: envName === 'prod' ? '2048' : '1024',
+      },
+      healthCheckConfiguration: {
+        protocol: 'HTTP',
+        path: '/health',
+        interval: 30,
+        timeout: 15,
+        healthyThreshold: 2,
+        unhealthyThreshold: 5,
+      },
+    });
+
+    // CloudWatch Logs for App Runner monitoring
+    new logs.LogGroup(this, 'OpenCVAppRunnerLogsGroup', {
+      retention: logs.RetentionDays.ONE_WEEK,
+    });
+
+    // Outputs
+    new cdk.CfnOutput(this, 'CfnOutputOpenCVAppRunnerServiceUrl', {
+      key: 'OpenCVAppRunnerServiceUrl',
+      description: 'OpenCV App Runner Service URL',
+      exportName: `${this.stackName}-OpenCVAppRunnerServiceUrl`,
+      value: `https://${this.appRunnerService.attrServiceUrl}`,
+    });
+
+    new cdk.CfnOutput(this, 'CfnOutputOpenCVAppRunnerServiceId', {
+      key: 'OpenCVAppRunnerServiceId',
+      description: 'OpenCV App Runner Service ID',
+      exportName: `${this.stackName}-OpenCVAppRunnerServiceId`,
+      value: this.appRunnerService.attrServiceId,
+    });
+  }
+}

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "2.198.0",
-        "boto3": "^0.0.1",
         "constructs": "^10.0.0"
       },
       "bin": {
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
+        "@types/aws-lambda": "^8.10.150",
         "@types/jest": "^29.5.14",
         "@types/node": "22.7.9",
         "aws-cdk": "2.1017.1",
@@ -1022,6 +1022,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.150",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.150.tgz",
+      "integrity": "sha512-AX+AbjH/rH5ezX1fbK8onC/a+HyQHo7QGmvoxAE42n22OsciAxvZoZNEr22tbXs8WfP1nIsBjKDpgPm3HjOZbA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1756,12 +1763,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/boto3": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/boto3/-/boto3-0.0.1.tgz",
-      "integrity": "sha512-IFT1HCaLUSzk//uM4++Lv65Rf/hT3GGjLWMkZvDuutPgV/uoWQFTpixfnWhOfWKFUFQxYeg0JbLfQ6PpQJBGYw==",
-      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,6 +11,7 @@
     "cdk": "cdk"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.150",
     "@types/jest": "^29.5.14",
     "@types/node": "22.7.9",
     "aws-cdk": "2.1017.1",

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -20,7 +20,6 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
-    "outDir": "./dist",
     "typeRoots": [
       "./node_modules/@types"
     ]

--- a/opencv/Dockerfile
+++ b/opencv/Dockerfile
@@ -11,18 +11,20 @@ RUN apt-get update && apt-get install -y \
     libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv.
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
-
-# Copy the application into the container.
-COPY . /app
-
-# Install the application dependencies.
+# Set working directory
 WORKDIR /app
-RUN uv sync --frozen --no-cache
+
+# Copy requirements first for better Docker layer caching
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the application code
+COPY . .
 
 # Expose port
 EXPOSE 5000
 
-# Run the application.
-CMD ["/app/.venv/bin/python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5000"]
+# Run the application
+CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/opencv/main.py
+++ b/opencv/main.py
@@ -3,6 +3,7 @@ FastAPI application for ArUco marker detection
 """
 
 import io
+import os
 import logging
 from typing import Dict, Any
 import cv2
@@ -24,10 +25,28 @@ app = FastAPI(
     version="1.0.0"
 )
 
+# Get environment variables
+ENVIRONMENT = os.getenv("ENVIRONMENT", "dev")
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+
+# Configure CORS origins based on environment
+if ENVIRONMENT == "prod":
+    # Production origins
+    allowed_origins = [
+        FRONTEND_URL,
+        "https://menkoverse.com",
+    ]
+else:
+    # Development origins
+    allowed_origins = [
+        "http://localhost:3000",
+        FRONTEND_URL,
+    ]
+
 # Add CORS middleware for web browser access
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],  # In production, specify actual origins
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/opencv/requirements.txt
+++ b/opencv/requirements.txt
@@ -1,0 +1,6 @@
+fastapi[standard]==0.116.1
+opencv-python-headless==4.8.0.74
+python-multipart==0.0.6
+pillow==10.0.0
+numpy==1.24.0
+uvicorn==0.30.0


### PR DESCRIPTION
- Use opencv-python-headless for smaller package size
- Add --no-cache-dir to pip install for faster builds
- Increase memory allocation to 1024MB for dev environment
- Add PYTHONUNBUFFERED environment variable
- Adjust health check timeout to 15 seconds
- Pin package versions for consistent builds