### PR TITLE
fix(opencv): use supported Python runtime version for App Runner

### DIFF
--- a/opencv/apprunner.yaml
+++ b/opencv/apprunner.yaml
@@ -10,7 +10,7 @@ build:
       - pip install --no-cache-dir -r requirements.txt
       - echo "Build completed successfully"
 run:
-  runtime-version: '3.12'
+  runtime-version: 3.11
   command: python -m uvicorn main:app --host 0.0.0.0 --port 5000
   network:
     port: 5000


### PR DESCRIPTION
- Change runtime-version from '3.12' to 3.11
- Use App Runner supported Python version
- Ensure compatibility with App Runner runtime environment