### PR TITLE
fix(opencv): update apprunner.yaml for Python 3.11 compatibility

### DIFF
--- a/opencv/apprunner.yaml
+++ b/opencv/apprunner.yaml
@@ -4,14 +4,14 @@ build:
   commands:
     build:
       - echo "Starting build process"
-      - python --version
-      - pip --version
-      - pip install --upgrade pip
-      - pip install --no-cache-dir -r requirements.txt
+      - python3 --version
+      - pip3 --version
+      - pip3 install --upgrade pip
+      - pip3 install --no-cache-dir -r requirements.txt
       - echo "Build completed successfully"
 run:
   runtime-version: 3.11
-  command: python -m uvicorn main:app --host 0.0.0.0 --port 5000
+  command: python3 -m uvicorn main:app --host 0.0.0.0 --port 5000
   network:
     port: 5000
   env:

--- a/opencv/pyproject.toml
+++ b/opencv/pyproject.toml
@@ -3,7 +3,7 @@ name = "opencv"
 version = "0.1.0"
 description = "ArUco marker detection API using OpenCV and FastAPI"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     "fastapi[standard]>=0.116.1",
     "opencv-python>=4.8.0",


### PR DESCRIPTION
- Change python to python3 commands in build and run sections
- Update pyproject.toml to require Python >= 3.11 instead of 3.12
- Fix App Runner build error: python command not found